### PR TITLE
Rewrite introduction for Dev Tools workshop on Dev Spaces

### DIFF
--- a/content/modules/ROOT/pages/00-introduction.adoc
+++ b/content/modules/ROOT/pages/00-introduction.adoc
@@ -4,62 +4,78 @@
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** Launching OpenShift Dev Spaces
+* **Prepares you for:** All subsequent labs
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
 * **Estimated Time:** 10 - 20 minutes
 ****
 
 [abstract]
-We will explore the Red Hat OpenShift Dev Spaces environment you will be working within and learn how to launch and configure development workspaces for Ansible automation development. This includes understanding the various components available in the lab environment, authenticating with git repositories, and using the Ansible Development Tools.
-
-This lab walks through the various components within the lab environment including launching, configuring and using Dev Spaces on OpenShift as your primary development environment for Ansible.
+This module introduces the Ansible Development Tools workshop and walks you through launching your development environment in Red Hat OpenShift Dev Spaces. By the end, you will have a fully configured VS Code workspace with all the tools needed for the remaining labs.
 
 == Learning Objectives
 
 After completing this module, you will be able to:
 
+* Understand what Ansible Development Tools are and why they matter
 * Navigate the Red Hat OpenShift Dev Spaces interface
-* Launch and configure development workspaces
-* Understand the components included in the lab environment
-* Set up authentication for git repositories
-* Use basic Ansible Development Tools features
+* Launch and configure your Ansible development workspace
+* Verify the installed development tools
 
-== 1: Introduction: What is included in the lab environment
+== What are Ansible Development Tools?
 
-. Red Hat OpenShift Cluster
-. Ansible Automation Platform
-. Red Hat OpenShift Dev Spaces
-. link:https://about.gitea.com[Gitea,window=_blank] Git Server
-. Windows 2019 managed host
-. Lab Instructions
+Ansible Development Tools (often referred to as _Ansible Dev Tools_ or `ansible-dev-tools`) are a curated bundle of command-line tools designed to support the entire Ansible content lifecycle.
 
-== 2: Contributing to this Lab Documentation
+These tools cover:
 
-If you see an error in this lab, fork and submit a pull request against https://github.com/rhpds/ansible-dev-tools-showroom
+* Project scaffolding (`ansible-creator`)
+* Local development environments (`ade`)
+* Linting and static analysis (`ansible-lint`)
+* Testing with ephemeral infrastructure (`molecule`, `pytest-ansible`, `tox-ansible`)
+* Content signing (`ansible-sign`)
+* Execution Environment creation (`ansible-builder`)
+* Execution and navigation (`ansible-navigator`)
 
-== 3: Dev Spaces console
+Instead of assembling and maintaining these tools individually, the bundle provides known-good versions and predictable integration between tools. All contributors use the same tools and compatible versions, reducing environment-related issues.
 
-link:https://access.redhat.com/products/red-hat-openshift-dev-spaces/[Red Hat OpenShift Dev Spaces,window=_blank] provides consistent, reproducible development environments based on the open-source project link:https://eclipse.dev/che/[Eclipse Che,window=_blank].
+In this workshop, you will use these tools through a consistent development workflow: *Create, Test, and Deploy* your automation content.
 
-It provides, by default, a Visual Studio Code (VS Code) environment as configured by a link:https://devfile.io[devfile,window=_blank], a YAML file that defines the entire workspace as code—including all necessary tools, runtimes, and project source. This file is used to instantly generate a pre-configured, containerized development environment, ensuring every developer on a team has an identical setup and solving the "it works on my machine" problem.
+== Lab environment
 
-=== 3.1: Launching Dev Spaces from OpenShift
+For this workshop, your development environment runs in link:https://access.redhat.com/products/red-hat-openshift-dev-spaces/[Red Hat OpenShift Dev Spaces^], which provides consistent, reproducible development environments based on the open-source project link:https://eclipse.dev/che/[Eclipse Che^].
 
-. Launch the link:{openshift_cluster_console_url}[OpenShift Web Console,window=_blank]
-. Select the **htpasswd_provider** button and use the credentials provided in the xref:environment-details.adoc[Environment Details,window=_blank] page to login to the OpenShift console
-. Use the 9-block icon in the upper right to launch _Red Hat OpenShift Dev Spaces_ directly from the OpenShift console header.
+Dev Spaces provides a VS Code environment configured by a link:https://devfile.io[devfile^], a YAML file that defines the entire workspace as code, including all necessary tools, runtimes, and project source. This ensures every participant has an identical setup.
+
+The lab environment includes:
+
+* Red Hat OpenShift cluster
+* Ansible Automation Platform
+* Red Hat OpenShift Dev Spaces (your development environment)
+* link:https://about.gitea.com[Gitea^] Git server
+* Lab instructions (this guide)
+
+== Lab tips
+
+Before we begin, here are some tips to improve your lab experience:
+
+* The **instructions sidebar** (where you are reading this) can be resized by dragging its border. This is useful if you need extra space for the main panel.
+
+* If you receive any **VS Code notification pop-ups**, you can safely ignore and dismiss them by clicking `x`, `Dismiss`, or `Ignore`, unless otherwise noted.
+
+* **Copy and pasting into the VS Code Terminal**: The key combo **Ctrl + Shift + V** (Mac: **Cmd + Shift + V**) should work for pasting. If using Firefox, you can also use the right-click menu for *Paste* into the Terminal.
+
+* The lab consists of several **Modules**. Each module contains one or more **Tasks**. When you finish a module, click the **Next** button at the bottom of the instructions sidebar to proceed.
+
+== Task 1: Launch the Dev Spaces workspace
+
+. Launch the link:{openshift_cluster_console_url}[OpenShift Web Console^]
+. Select the **htpasswd_provider** button and use the credentials provided in the xref:environment-details.adoc[Environment Details] page to log in to the OpenShift console
+. Use the 9-block icon in the upper right to launch _Red Hat OpenShift Dev Spaces_ directly from the OpenShift console header
 +
 image::11-platform-dev-spaces/intro-dev_spaces_shortcut.png[OpenShift console header showing the 9-block application launcher icon for quick access to Dev Spaces,link=self,window=blank]
 +
-TIP: Alternatively, the direct URL is link:https://devspaces.{openshift_cluster_ingress_domain}[https://devspaces.{openshift_cluster_ingress_domain},window=_blank] also available in xref:environment-details.adoc[Environment Details,window=_blank].
+TIP: Alternatively, the direct URL is link:https://devspaces.{openshift_cluster_ingress_domain}[https://devspaces.{openshift_cluster_ingress_domain}^] also available in xref:environment-details.adoc[Environment Details].
 
-== 4: Dev Spaces Workspace
-
-=== 4.1: Launching a specific Dev Spaces Workspace
-
-Once you have launched the OpenShift Dev Spaces console, use the following steps to access your Ansible Dev Space workspace.
-
-. Login via OpenShift authentication using the same credentials as the OpenShift console
+. Log in via OpenShift authentication using the same credentials as the OpenShift console
 . Select **Allow selected permissions** to authorize access and launch the console
 . Scroll down and select the workspace titled **Ansible Dev Space**
 +
@@ -68,41 +84,32 @@ image::11-platform-dev-spaces/intro3.png[Dev Spaces workspace selection page sho
 NOTE: It will take a few minutes for the Dev Spaces instance to initialize. When it has loaded, a Visual Studio Code interface will appear.
 +
 image::11-platform-dev-spaces/intro4.png[Dev Spaces workspace loading screen showing VS Code interface initialization,link=self,window=blank]
-+
+
 . Click the **Trust Publishers and Install** button to trust the extension publishers that are included within the Dev Spaces workspace
-. Click the **Yes, I trust the Authors** button to trust the workspace authors (your instructors).
-. Wait a few minutes until the additional extension icons appear for Ansible and OpenShift on the left side.
+. Click the **Yes, I trust the Authors** button to trust the workspace authors
+. Wait a few minutes until the additional extension icons appear for Ansible and OpenShift on the left side
 +
 image::11-platform-dev-spaces/intro5.png[VS Code interface in Dev Spaces showing Ansible and OpenShift extension icons in the left sidebar,link=self,window=blank]
 
-== 5: Ansible and OpenShift Extensions
+== Task 2: Configure the extensions
 
-For this lab, we have provided a link:https://code.visualstudio.com/docs/editing/workspaces/workspaces[.code-workspace,window=_blank] configuration that included these extensions along with additional configurations to curate your development environment. See https://github.com/jeffcpullen/devspaces-example/blob/main/devspaces.code-workspace for the source of this workspace configuration.
+. Check the **Extensions** section in VS Code, look for the Ansible extension and click the blue **Reload Window** button to update to the latest version
++
+image::vscode-devtools-extension-reload.png[Reload extensions in VS Code,link=self,window=blank, opts="border"]
 
-. Click on the **Ansible** extension icon to access the Ansible Development Tools extension (covered in a subsequent lab)
+. Click on the **Ansible** extension icon in the left sidebar to verify the Ansible Development Tools extension is available
 +
 image::11-platform-dev-spaces/intro6.png[Ansible extension interface in VS Code showing available Ansible development tools,link=self,window=blank]
 
-== 6: Accessing a Terminal
+== Task 3: Verify the development environment
 
-The majority of the exercises in this lab will be performed using the Visual Studio Code terminal.
+The majority of the exercises in this lab will be performed using the VS Code terminal.
 
 . Open a new terminal by selecting the VS Code menu starting with the hamburger (3 horizontal lines) in the top left, then selecting **Terminal** -> **New Terminal**
 +
 image::11-platform-dev-spaces/intro7.png[VS Code terminal interface showing basic command line operations in the Dev Spaces environment,link=self,window=blank]
-+
-. Explore the environment:
-+
-[source,bash,role=execute,subs="verbatim,attributes"]
-----
-whoami
-----
-+
-[source,output]
-----
-user
-----
-. Check the Dev Spaces Workspace container OS release:
+
+. Verify the container OS release:
 +
 [source,bash,role=execute,subs="verbatim,attributes"]
 ----
@@ -113,34 +120,34 @@ cat /etc/redhat-release
 ----
 Red Hat Enterprise Linux release 9.7 (Plow)
 ----
-. This workspace provides access to `ansible` and additional developer tools:
+
+. Verify `ansible` and the development tools are available:
 +
 [source,bash,role=execute,subs="verbatim,attributes"]
 ----
-ansible --version
+adt --version
 ----
 +
-[source,output]
+NOTE: The output will show the versions of all installed Ansible development tools. Versions may differ from the examples in the lab, this is expected.
+
+. Due to workshop limitations, update the tools and pin the `ansible-core` version:
++
+[source,sh,role=execute]
 ----
-ansible [core 2.19.3]
-  config file = None
-  configured module search path = ['/home/user/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
-  ansible python module location = /usr/local/lib/python3.11/site-packages/ansible
-  ansible collection location = /home/user/.ansible/collections:/usr/share/ansible/collections
-  executable location = /usr/local/bin/ansible
-  python version = 3.11.13 (main, Aug 21 2025, 00:00:00) [GCC 11.5.0 20240719 (Red Hat 11.5.0-11)] (/usr/bin/python3.11)
-  jinja version = 3.1.6
-  pyyaml version = 6.0.3 (with libyaml v0.2.5)
+pip3 install --upgrade ansible-dev-tools
+pip3 install ansible-core==2.16.15
 ----
 
 == Conclusion
 
-In this lab, you have learned:
+In this module, you have:
 
-. The resources provided in the lab environment
-. Assessing the OpenShift environment
-. How to launch and navigate an Red Hat OpenShift Dev Spaces workspace
-. How to provide feedback and contributions to this lab environment
+* Learned what Ansible Development Tools are and how they support the content lifecycle
+* Launched and configured your Red Hat OpenShift Dev Spaces workspace
+* Verified the development tools are installed and ready
 
-This foundation prepares you to start your Ansible Bootcamp Enablement journey.
+This foundation prepares you for the remaining labs where you will create, test, and deploy Ansible automation content.
 
+== Contributing to this lab
+
+If you see an error in this lab, fork and submit a pull request against link:https://github.com/rhpds/ansible-dev-tools-showroom[https://github.com/rhpds/ansible-dev-tools-showroom^]


### PR DESCRIPTION
## Summary

- Rewrites `00-introduction.adoc` to focus on the Ansible Development Tools workshop running in OpenShift Dev Spaces
- Replaces content from the wider Ansible Bootcamp workshop with dev-tools-specific context
- Incorporates lab tips and environment setup from the [reference module](https://github.com/rhpds/zt-ans-bu-dev-tools/blob/event-rh1-2026/content/modules/ROOT/pages/module-01.adoc)

## Key changes

- **Added "What are Ansible Development Tools?" section** -- explains the bundle concept, lists all tools with CLI names, and frames the Create/Test/Deploy workflow
- **Added "Lab tips" section** -- copy/paste workarounds, sidebar resizing, navigation tips
- **Moved `pip install` workaround to introduction** -- done once at the start instead of mid-lab in `12-ade.adoc`
- **Replaced `ansible --version` with `adt --version`** -- shows all dev tools at once
- **Removed irrelevant content** -- "Windows 2019 managed host", "Ansible Bootcamp Enablement" references
- **Restructured into Tasks** -- Task 1 (launch workspace), Task 2 (configure extensions), Task 3 (verify environment)
- **Used `^` caret** for external links instead of `window=_blank`

## Test plan

- [ ] Preview site locally and verify `00-introduction.adoc` renders correctly
- [ ] Verify all images still display (same images, no paths changed)
- [ ] Verify xrefs to `environment-details.adoc` resolve
- [ ] Check the flow from introduction into `11-vscode-collection.adoc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)