### PR TITLE
Add environment details and appendix to navigation

### DIFF
--- a/content/modules/ROOT/nav.adoc
+++ b/content/modules/ROOT/nav.adoc
@@ -13,3 +13,5 @@
 *** xref:31-ansible-builder.adoc[Lab 3.1 - Creating an Execution Environment with ansible-builder]
 *** xref:32-ansible-sign.adoc[Lab 3.2 - Introducing supply chain security with ansible-sign]
 ** xref:99-conclusion.adoc[Conclusion]
+* xref:environment-details.adoc[Environment Details]
+* xref:appendix.adoc[Appendix]


### PR DESCRIPTION
## Summary

- Adds `environment-details.adoc` and `appendix.adoc` to the sidebar navigation
- These pages were created in PR #4 but were not added to `nav.adoc`

## Test plan

- [ ] Verify "Environment Details" and "Appendix" appear in sidebar after Conclusion
- [ ] Verify links navigate to the correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)