### PR TITLE
Fix content quality issues from second review

### DIFF
--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -78,7 +78,7 @@ First, let's explore the Ansible extension for VS Code.
 +
 image::vscode-devtools-extension-reload.png[Reload extensions in VS Code,link=self,window=blank, opts="border"]
 
-.   After the window reloads, locate and open the **Ansible extension icon on the sidebar of VS Code** and click on it. You will see the Ansible sidebar with three sections: (1) *Ansible Development Tools*, (2) *Ansible Lightspeed*, and (3) *Ansible Lightspeed Feedback*.
+.   After the window reloads, locate and open the **Ansible extension icon on the sidebar of VS Code** and click on it. You will see the Ansible sidebar with 3 sections: (1) *Ansible Development Tools*, (2) *Ansible Lightspeed*, and (3) *Ansible Lightspeed Feedback*.
 +
 image::vscode-devtools-ansible-icon.png[Ansible icon in VS Code sidebar,link=self,window=blank, opts="border"]
 

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -152,12 +152,12 @@ image::vscode-devtools-cowsay-run2.png[Ansible Navigator TUI,link=self,window=bl
 
 .   **Explore the Navigator output.** You are now inside the `ansible-navigator` TUI.
 * To the left of the play name, you will see the number `0`. **Press `0`** to drill down into the details for that play.
-* You can now see the three tasks from your playbook. **Press `2`** to see the output of the final "Display the result" task.
+* You can now see the 3 tasks from your playbook. **Press `2`** to see the output of the final "Display the result" task.
 * You may need to scroll down to find the cow message.
 +
 image::vscode-devtools-cowsay-navigator.png[Viewing task output in Ansible Navigator,link=self,window=blank, opts="border"]
 
-.   **Exit Ansible Navigator.** **Press** the `ESC` key three times to exit the TUI and return to the normal terminal prompt.
+.   **Exit Ansible Navigator.** **Press** the `ESC` key 3 times to exit the TUI and return to the normal terminal prompt.
 
 ---
 == Next Steps

--- a/content/modules/ROOT/pages/21-molecule.adoc
+++ b/content/modules/ROOT/pages/21-molecule.adoc
@@ -16,6 +16,15 @@ _A guide to testing your Ansible collection using Ansible Molecule and a pre-con
 * **Estimated Time:** 
 ****
 
+== Learning Objectives
+
+After completing this module, you will be able to:
+
+* Describe the Molecule test lifecycle and its stages
+* Configure a Molecule test scenario using `molecule.yml`
+* Write assertion-based integration tests for Ansible content
+* Run and troubleshoot Molecule test scenarios from the command line
+
 == Lab Briefing
 
 In this challenge, you will explore and test the collection you created in previous modules using **Ansible Molecule**.
@@ -31,7 +40,7 @@ Ansible Molecule is a tool designed to aid in developing and testing Ansible pla
 * **Integration:** Tests that your collection components work correctly with systems and services
 * **Assertions:** Validates that expected outcomes are achieved
 
-**Scenarios** are the starting point for Molecule's powerful functionality. Think of a scenario as a test suite for your Ansible content. Each scenario defines:
+**Scenarios** are the starting point for Molecule's core functionality. Think of a scenario as a test suite for your Ansible content. Each scenario defines:
 
 * The test environment (containers, VMs, cloud instances)
 * The sequence of actions to perform (create, converge, verify, destroy)

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -28,7 +28,7 @@ After completing this module, you will be able to:
 
 == Lab Briefing
 
-pytest-ansible is a pytest plugin that bridges the gap between Python's pytest framework and Ansible automation. It provides three key capabilities:
+pytest-ansible is a pytest plugin that bridges the gap between Python's pytest framework and Ansible automation. It provides 3 key capabilities:
 
 * *Ansible execution in tests*: Run Ansible modules and tasks directly from your test code
 * *Collection unit test runner*: Use pytest as a test runner for Ansible collections
@@ -176,7 +176,7 @@ def test_cowsay_module(ansible_module):
 +
 [NOTE]
 ====
-This test validates both the module's execution (no failures, correct change state) and its output (contains the expected message with cowsay formatting). The assertions check for structural elements that are always present in cowsay output, making the test more robust than checking for specific ASCII art.
+This test validates both the module's execution (no failures, correct change state) and its output (contains the expected message with cowsay formatting). The assertions check for structural elements that are always present in cowsay output, making the test more reliable than checking for specific ASCII art.
 ====
 
 ---

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -164,7 +164,7 @@ This automatically:
 
 === Task 5: Running a Group of Tests
 
-One of the most powerful features of tox is running multiple tests with one command.
+A key feature of tox is running multiple tests with one command.
 
 .   **Run all tests for a specific Ansible version:**
     You can use "factors" to match multiple environments.

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -264,7 +264,7 @@ The `-vvv` flag specifies the verbosity level of the output and is not related t
 
 . *Verify the image creation:*
 +
-The build command executes the container build across four internal stages: Base, Galaxy, Builder, and Final. After the build completes successfully, you should see a message similar to this one:
+The build command executes the container build across 4 internal stages: Base, Galaxy, Builder, and Final. After the build completes successfully, you should see a message similar to this one:
 +
 [source,bash]
 ----

--- a/content/modules/ROOT/pages/99-conclusion.adoc
+++ b/content/modules/ROOT/pages/99-conclusion.adoc
@@ -25,9 +25,9 @@ You have successfully completed the **"Intro to creating automation with the new
 
 **Scan** the QR code below to sign up to the Ansible Forum if you haven't yet, if you already have scan anyway and you might get a Badge for completing the workshop if you approach your instructor with your username!
 
-image:qr-ansible-forum-workshop-completed.png[QR code for Ansible Forum, opts="border"]
+image::qr-ansible-forum-workshop-completed.png[QR code for Ansible Forum,link=self,window=blank, opts="border"]
 
-After logging in to the Ansible Forum, link:https://forum.ansible.com/t/introduce-yourself-2026-edition/45062?u=leo[introduce yourself in this topic] and feel free to mention that you just completed the Ansible Developer Tools lab!
+After logging in to the Ansible Forum, link:https://forum.ansible.com/t/introduce-yourself-2026-edition/45062?u=leo[introduce yourself in this topic^] and feel free to mention that you just completed the Ansible Developer Tools lab!
 
 [IMPORTANT]
 ====
@@ -38,7 +38,7 @@ Check the "Next Steps" section below to learn how to get the Ansible development
 
 == Review of learned concepts
 
-You have reached the end of the *Introduction to Ansible development tools* workshop. In this lab, you learned about and used some of the most important tools available to Ansible developers:
+You have reached the end of the *Introduction to Ansible development tools* workshop. In this lab, you learned about and used some of the key tools available to Ansible developers:
 
 * The **Ansible extension for VS Code** for a rich editing experience.
 * **`ansible-creator`** to scaffold new collections and content.
@@ -56,7 +56,7 @@ If you would like to get all of these tools running on your own Windows, macOS, 
 
 .Interactive Guide
 ****
-link:https://interact.redhat.com/share/iKoPpilaNueRFTUzWnqL[Installing Ansible developer tools in VS Code in Windows, macOS or Linux using the Dev Container]
+link:https://interact.redhat.com/share/iKoPpilaNueRFTUzWnqL[Installing Ansible developer tools in VS Code in Windows, macOS or Linux using the Dev Container^]
 ****
 
 == References

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -47,7 +47,7 @@ By the end of this workshop, you will be able to:
 
 * Use the **Ansible extension for VS Code** features for a rich editing experience.
 * Learn all the creation tools, including `ansible-creator` to scaffold new collections and content, `adt` (Ansible development tools) for a unified command-line tools management, `ade` (Ansible development environment) for managing collection dependencies and virtual environments and `ansible-navigator` for a feature-rich terminal-based user interface to run and test your execution environments..
-* Test your content with `ansible-lint` for checking playbooks against best practices, `molecule` for robustly testing your collections, `pytest-ansible` for functional testing of your modules and tox-ansible for bringing it all together against in multiple combinations.
+* Test your content with `ansible-lint` for checking playbooks against best practices, `molecule` for robustly testing your collections, `pytest-ansible` for functional testing of your modules, and `tox-ansible` for bringing it all together against in multiple combinations.
 * Deploy to production by packaging your Collection content with `ansible-galaxy` and `ansible-builder`, and applying secure supply chain practices with `ansible-sign`.
 
 == Getting Started


### PR DESCRIPTION
## Summary
- Add missing Learning Objectives section to `21-molecule.adoc`
- Fix 2 external links in `99-conclusion.adoc` missing `^` caret (new tab)
- Replace prohibited vague terms: "powerful" → "core"/"key", "robust" → "reliable"
- Replace unsupported superlatives: "most powerful" → "key feature", "most important" → "key"
- Convert written numbers to numerals (three → 3, four → 4) per Red Hat style guide
- Add missing Oxford comma in `index.adoc` learning outcomes list
- Fix QR code image: inline `image:` → block `image::` with `link=self,window=blank`

## Test plan
- [ ] Verify Antora build succeeds
- [ ] Spot-check affected pages render correctly
- [ ] Confirm Learning Objectives section in 21-molecule.adoc matches other modules' format

🤖 Generated with [Claude Code](https://claude.com/claude-code)