### PR TITLE
Apply Red Hat style guide compliance fixes

### DIFF
--- a/content/modules/ROOT/pages/00-introduction.adoc
+++ b/content/modules/ROOT/pages/00-introduction.adoc
@@ -12,7 +12,7 @@
 [abstract]
 This module introduces the Ansible Development Tools workshop and walks you through launching your development environment in Red Hat OpenShift Dev Spaces. By the end, you will have a fully configured VS Code workspace with all the tools needed for the remaining labs.
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -17,7 +17,7 @@ _A guide to using the Ansible extension for Visual Studio Code to scaffold a new
 * **Estimated Time:**  
 ****
 
-== Lab Briefing
+== Lab briefing
 
 `ansible-creator` is a Command-Line Interface (CLI) tool designed for effortlessly scaffolding all your Ansible content. Whether you are initializing an Ansible collection or creating the framework for specific plugins, this tool streamlines the process with efficiency and precision based on your requirements.
 
@@ -25,7 +25,7 @@ _A guide to using the Ansible extension for Visual Studio Code to scaffold a new
 
 In this exercise, you will create an Ansible collection and a playbook using the Ansible extension's wizard in VS Code.
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -37,14 +37,14 @@ image::Jun-06-2025_at_21.02.34-image.png[VS Code editor inside the lab environme
 
 ---
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
 In this exercise you will learn how to create, test, and deploy an Ansible collection using the `ansible-creator` tool through the Ansible extension for VS Code.
 
 For this lab, all necessary tools and dependencies are pre-installed and configured for you.
 
 
-=== Task 0: Create a Collection Using the ansible-creator CLI
+=== Task 0: Create a collection using the ansible-creator CLI
 
 Lets start by running `ansible-creator` in the command line to scaffold a collection, with the directory structure and several file templates to speed up our content development. In the following tasks we will do the same using the Ansible extension in VS Code.
 
@@ -70,7 +70,7 @@ NOTE: You should see the scaffolded collection directory structure including fil
 
 . **Congrats:** You created a default collection. Move to the next tasks to see how to do this in VS Code and how to customize it.
 
-=== Task 1: Explore the Ansible Extension
+=== Task 1: Explore the Ansible extension
 
 First, let's explore the Ansible extension for VS Code.
 
@@ -86,7 +86,7 @@ image::vscode-devtools-ansible-icon.png[Ansible icon in VS Code sidebar,link=sel
 +
 image::Apr-29-2025_at_13.49.45-image.png[Collapsing the Lightspeed sections,link=self,window=blank, opts="border"]
 
-=== Task 2: Create a Collection Project
+=== Task 2: Create a collection project
 
 Next, you will scaffold a new Ansible collection.
 
@@ -137,7 +137,7 @@ Note: Please activate the virtual environment:
 source /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/.venv/bin/activate
 ----
 
-=== Task 3: Create a Playbook Project
+=== Task 3: Create a playbook project
 
 Now, you will create a separate playbook project.
 
@@ -177,7 +177,7 @@ image::vscode-devtools-playbook-create.png[Creating a Playbook project,link=self
 Note: playbook project created at /home/rhel/myansibleproject
 ----
 
-=== Task 4: Open the `mycollection` Folder
+=== Task 4: Open the mycollection folder
 
 Due to a lab infrastructure and VS Code limitation, you will now manually open the folder where your new collection content was created.
 
@@ -207,6 +207,6 @@ image::May-06-2025_at_21.58.21-image.png[Scaffolded collection files in the Expl
 
 ---
 
-== Next Steps
+== Next steps
 
 You have successfully explored how ansible-creator and VS Code work together to scaffold a collection. Please click the **Next** button below to proceed to the next module.

--- a/content/modules/ROOT/pages/12-ade.adoc
+++ b/content/modules/ROOT/pages/12-ade.adoc
@@ -17,7 +17,7 @@ _A guide to exploring what `ansible-creator` and `ade` (Ansible Dev Environment)
 * **Estimated Time:** 
 ****
 
-== Lab Briefing
+== Lab briefing
 
 Ansible Dev Environment (`ade`) is a management tool for Ansible content development that provides isolated workspaces for development. `ade` manages virtual environments, collection installation and removal, and Python dependency resolution to ensure consistent, reproducible development environments.
 
@@ -33,7 +33,7 @@ Ansible Dev Environment (`ade`) is a management tool for Ansible content develop
 
 In this challenge, you will explore the content that was automatically generated for the collection you just created and learn how to customize your requirements using `ade`.
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -45,7 +45,7 @@ image::May-06-2025_at_21.58.21-image.png[Scaffolded collection files in the Expl
 
 ---
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
 You will now set up your Ansible development environment, check the scaffolded collection content, and add a dependency to your collection's `galaxy.yml` to see how the new `ade` tool helps manage it.
 
@@ -63,7 +63,7 @@ image::vscode-devtools-python-env.png[Selecting the Python virtual environment i
 
 NOTE: This is a convenient alternative to manually running `source .venv/bin/activate` in the terminal.
 
-=== Task 2: Add Collection Dependencies
+=== Task 2: Add collection dependencies
 
 The Ansible Development Environment (`ade`) tool helps manage dependencies for your collections. 
 
@@ -158,7 +158,7 @@ pip3 install --upgrade ansible-dev-tools
 pip3 install ansible-core==2.16.15
 ----
 
-=== Task 4: Manage Dependencies with `ade`
+=== Task 4: Manage dependencies with `ade`
 
 Now you will use `ade` to install the dependencies you declared in `galaxy.yml`.
 
@@ -224,7 +224,7 @@ NOTE: Remember the "Install collection from source code (editable mode)" option 
 ---
 
 
-== Next Steps
+== Next steps
 
 You have successfully explored how Ansible Dev Tools (`adt`) and Ansible Dev Environment (`ade`) work. Please click the **Next** button below to proceed to the next module.
 

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -17,11 +17,11 @@ _A guide to adding a custom module to your Ansible collection and using it in a 
 * **Estimated Time:**
 ****
 
-== Lab Briefing
+== Lab briefing
 
 In this challenge, you will be adding content in the form of a Ansible **module plugin** to the collection you created, and then using the module for a new playbook, which you will fix with `ansible-lint` before running it with `ansible-navigator`.
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -32,7 +32,7 @@ After completing this module, you will be able to:
 
 ---
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
 In this exercise, you will copy an existing Python module into your collection's `plugins/modules` directory. While you can develop your own modules from scratch, we will use a pre-written one for simplicity.
 
@@ -160,6 +160,6 @@ image::vscode-devtools-cowsay-navigator.png[Viewing task output in Ansible Navig
 .   **Exit Ansible Navigator.** **Press** the `ESC` key 3 times to exit the TUI and return to the normal terminal prompt.
 
 ---
-== Next Steps
+== Next steps
 
 You have successfully added and tested a custom module in your collection. Please click the **Next** button below to proceed to the next module.

--- a/content/modules/ROOT/pages/21-molecule.adoc
+++ b/content/modules/ROOT/pages/21-molecule.adoc
@@ -16,7 +16,7 @@ _A guide to testing your Ansible collection using Ansible Molecule and a pre-con
 * **Estimated Time:** 
 ****
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -25,7 +25,7 @@ After completing this module, you will be able to:
 * Write assertion-based integration tests for Ansible content
 * Run and troubleshoot Molecule test scenarios from the command line
 
-== Lab Briefing
+== Lab briefing
 
 In this challenge, you will explore and test the collection you created in previous modules using **Ansible Molecule**.
 
@@ -68,14 +68,14 @@ This lifecycle ensures your content is tested in a clean, reproducible environme
 
 ---
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
 Now, let's explore the test scenario that was automatically added to your collection project.
 
 ---
 
 
-=== Task 1: Explore the Molecule Scenario
+=== Task 1: Explore the Molecule scenario
 
 When you created the collection in the previous modules, `ansible-creator` also generated a Molecule test scenario named `integration_hello_world`.
 
@@ -112,7 +112,7 @@ This playbook runs during the **converge** stage of the Molecule lifecycle. It's
 ---
 
 
-=== Task 2: Examine the Integration Tests
+=== Task 2: Examine the integration tests
 
 Before running tests, let's understand what those tests actually verify. This is where assertion-based testing comes into play.
 
@@ -145,7 +145,7 @@ This setup → execute → verify pattern is fundamental to effective testing.
 ---
 
 
-=== Task 3: Create a Filter Plugin
+=== Task 3: Create a filter plugin
 
 Now that you understand how tests work, let's add a new filter plugin to your collection. This demonstrates how new components integrate with the existing Molecule test framework - when you add functionality, you can immediately test it.
 
@@ -176,7 +176,7 @@ The Ansible extension creates the plugin structure automatically, including the 
 ---
 
 
-=== Task 4: Run the Molecule Test
+=== Task 4: Run the Molecule test
 
 Finally, you will use the command line to run the Molecule test scenario and observe the complete test lifecycle in action.
 
@@ -238,7 +238,7 @@ A passing Molecule test means your collection has been validated in an automated
 
 ---
 
-=== Troubleshooting Common Issues
+=== Troubleshooting common issues
 
 . **If you see "No such file or directory" errors:**
 +
@@ -308,8 +308,8 @@ The skills you've learned in this module - understanding test scenarios, writing
 
 ---
 
-== Next Steps
+== Next steps
 
-You have successfully used Molecule to test your collection. In the next module, you'll explore additional development tools and best practices for maintaining production-ready Ansible content. 
+You have successfully used Molecule to test your collection. In the next module, you'll explore additional development tools and recommended practices for maintaining production-ready Ansible content. 
 
 Please click the **Next** button below to proceed to the next module.

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -17,7 +17,7 @@ _Learn how to do functional testing for your Ansible content using pytest-ansibl
 * **Estimated Time:**
 ****
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -26,7 +26,7 @@ After completing this module, you will be able to:
 * Configure `conftest.py` for proper module and collection path resolution
 * Interpret pytest output and use debugging flags
 
-== Lab Briefing
+== Lab briefing
 
 pytest-ansible is a pytest plugin that bridges the gap between Python's pytest framework and Ansible automation. It provides 3 key capabilities:
 
@@ -38,7 +38,7 @@ This integration allows you to write fast, isolated tests for Ansible modules, p
 
 In this lab, you'll learn how to test the custom `cowsay` module you developed earlier using pytest-ansible.
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
 === Why pytest-ansible?
 
@@ -55,7 +55,7 @@ These tests run quickly and are well-suited for CI pipelines.
 
 ---
 
-=== Test Scope
+=== Test scope
 
 In this task, we will test the custom `cowsay` module developed earlier in the collection:
 
@@ -65,7 +65,7 @@ In this task, we will test the custom `cowsay` module developed earlier in the c
 
 ---
 
-=== Task 1: Create the Test Inventory
+=== Task 1: Create the test inventory
 
 . *Create the `inventory` file inside the `mycollection/tests` directory:*
 +
@@ -77,7 +77,7 @@ localhost ansible_connection=local ansible_python_interpreter=python3
 
 ---
 
-=== Task 2: Create the Test Configuration
+=== Task 2: Create the test configuration
 
 . *Inside the `mycollection/tests/` directory*, create a `conftest.py` file with the following content:
 +
@@ -123,7 +123,7 @@ The `conftest.py` file is a special pytest configuration file that runs before a
 
 ---
 
-=== Task 3: Create the Test File
+=== Task 3: Create the test file
 
 . *Inside the `mycollection/tests/` directory*, create a `test_cowsay.py` file and add the following content:
 +
@@ -181,7 +181,7 @@ This test validates both the module's execution (no failures, correct change sta
 
 ---
 
-=== Task 4: Run the Test
+=== Task 4: Run the test
 
 . *Open the VS Code Terminal if you don't have one*
 
@@ -277,7 +277,7 @@ Molecule validates *how content behaves in a system context*, while pytest-ansib
 
 ---
 
-=== When to Use Each Tool
+=== When to use each tool
 
 * Use Molecule when testing:
 ** Roles
@@ -293,7 +293,7 @@ Both tools complement each other and are commonly used together in professional 
 
 ---
 
-=== Key Takeaways
+=== Key takeaways
 
 * Molecule ensures your automation works in real environments.
 * pytest-ansible ensures your building blocks behave correctly.

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -16,7 +16,7 @@ _A guide to automating your testing workflow using the tox-ansible plugin._
 * **Estimated Time:** 10 - 20 minutes
 ****
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -24,7 +24,7 @@ After completing this module, you will be able to:
 * Run linting, unit, and integration tests through a unified `tox` interface
 * Target specific Ansible versions and test types using tox factors
 
-== Lab Briefing
+== Lab briefing
 
 **What is tox?**
 `tox` is a generic virtual environment management and test command line tool. It is the standard for testing Python-based projects.
@@ -41,9 +41,9 @@ This "Convention over Configuration" approach allows you to run complex test mat
 
 ---
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
-=== Task 1: Verify the Installation
+=== Task 1: Verify the installation
 
 Before we configure anything, let's verify that `tox` and the plugin are installed and ready.
 
@@ -69,7 +69,7 @@ Crucially, look for **`with tox-ansible`**. This confirms the plugin is active.
 cd /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/
 ----
 
-=== Task 2: Create a Minimal tox Configuration
+=== Task 2: Create a minimal Tox configuration
 
 Because we are using the plugin, we don't need to manually define every single test environment. We just need to tell tox global settings.
 
@@ -108,7 +108,7 @@ ansible_core_versions =
     * `ansible_core_versions`: The plugin normally attempts to test against *every* supported Ansible version. We limit this to 2.15 and 2.16 to keep the lab fast.
     * We do *not* have a `[testenv:lint]` or `[testenv:molecule]` section. The plugin creates these for us!
 
-=== Task 3: Explore the Auto-Generated Environments
+=== Task 3: Explore the auto-generated environments
 
 Now that the config exists, let's see what the plugin found in your project.
 
@@ -126,7 +126,7 @@ Even though your `tox.ini` is tiny, you will see a massive list of environments.
 * `py311-ansible2.16-unit` (Auto-discovered pytest)
 * `py311-ansible2.16-molecule-integration_hello_world` (Auto-discovered molecule)
 
-=== Task 4: Run the Tests
+=== Task 4: Run the tests
 
 Now we let tox orchestrate the execution.
 
@@ -162,7 +162,7 @@ This automatically:
     3.  Installs Molecule and Podman plugins.
     4.  Executes the test scenario.
 
-=== Task 5: Running a Group of Tests
+=== Task 5: Running a group of tests
 
 A key feature of tox is running multiple tests with one command.
 
@@ -198,7 +198,7 @@ In this lab, you utilized the **tox-ansible** plugin to dramatically simplify te
 * **Auto-discovery:** You learned how the plugin scans your project to generate the test matrix automatically.
 * **Matrix Testing:** You validated your code against specific Ansible Core versions (2.15, 2.16) without managing the dependencies manually.
 
-== Next Steps
+== Next steps
 
 With your testing pipeline automated, you are ready to package your work.
 Click the **Next** button below to proceed to **Module 08: Execution Environments**.

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -16,7 +16,7 @@ _A guide to automating the creation and customization of containerized execution
 * **Estimated Time:** 10 - 20 minutes
 ****
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -26,7 +26,7 @@ After completing this module, you will be able to:
 * Build and tag a custom execution environment image
 * Test the execution environment with `podman` and `ansible-navigator`
 
-== Lab Briefing
+== Lab briefing
 
 In previous challenges, you authored, tested, and validated your custom Ansible collection. 
 
@@ -43,11 +43,11 @@ The Ansible VS Code extension is actively providing an Enhanced VS Code integrat
 
 Although new features in the roadmap are coming to simplify the EE building experience, specially for operators and deploying in production, this exercise covers the development and testing.
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
 We will define an Execution Environment configuration file by using the Ansible extension wizard in VS Code, then use  `ansible-galaxy` to package our collection, `ansible-builder create` to inspect the generated `Containerfile`, and finally `ansible-builder build` for building the custom EE image, and finish by testing it using Podman (the default container runtime).
 
-=== Task 1: Define the Execution Environment Definition File
+=== Task 1: Define the Execution Environment definition file
 
 
 The EE configuration is defined in `execution-environment.yml`. To access the features of modern Ansible tooling, we must explicitly declare `version: 3` in the definition file.
@@ -135,7 +135,7 @@ Because the base image (`ee-minimal-rhel8:latest`) is built on Universal Base Im
 
 . *Let's customize the EE blueprint content:*
 +
-We will be making two modifications to the created file, as we are building an EE to test our local developed collection, we need to specify to `ansible-builder` we will be working with a local tarball, as our collection is not yet available in Ansible Galaxy or AAP's Automation Hub.
+We will be making two modifications to the created file, as we are building an EE to test our local developed collection, we need to specify to `ansible-builder` we will be working with a local tarball, as our collection is not yet available in Ansible Galaxy or Ansible Automation Platform's (AAP) Automation Hub.
 +
 First we will add a section called `additional_build_files`, where we will input the source (`src`) file of the collection and the destination (`dest`) for the build context
 +
@@ -211,7 +211,7 @@ ade install -e .
 ----
 
 
-=== Task 2: Review the Generated Containerfile (Dry Run)
+=== Task 2: Review the generated Containerfile (dry run)
 
 Before executing the full build, we can use the `ansible-builder create` command to generate the `Containerfile` and build context directory (`context/`). This is helpful for debugging the build steps without spending time on the full image assembly.
 
@@ -243,7 +243,7 @@ In the VS Code file explorer, locate `context/Containerfile` and open it. Review
 
 
 
-=== Task 3: Build and Tag the Custom Execution Environment
+=== Task 3: Build and tag the custom Execution Environment
 
 Now we will execute the full build process and assign a specific tag to the final container image.
 
@@ -331,6 +331,6 @@ podman run mynamespace/mycollection-ee:latest ansible-doc -t module mynamespace.
 IMPORTANT: This command should display the documentation for your custom module, but we didn't add the corresponding metadata blocks! We will leave it to you as an optional task to research and fix this issue if you have time after finishing the lab!
 
 ---
-== Next Steps
+== Next steps
 
 You have successfully packaged your automation content into an Execution Environment using `ansible-builder` and VS Code. This image is now ready for upload to an Automation Hub or deployment via Automation Controller. Please click the **Next** button below to proceed to the next module.

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -17,7 +17,7 @@ _Learn how to sign content by using ansible-sign and apply supply-chain security
 * **Estimated Time:** 10 - 20 minutes
 ****
 
-== Learning Objectives
+== Learning objectives
 
 After completing this module, you will be able to:
 
@@ -26,13 +26,13 @@ After completing this module, you will be able to:
 * Sign and verify an Ansible project using `ansible-sign`
 * Understand how signed content integrates with Ansible Automation Platform
 
-== Lab Briefing
+== Lab briefing
 
 `ansible-sign`: Utility for signing and verifying Ansible project directory contents.
 
 Project signing and verification lets you sign files in your project directory, then verify whether or not that content has changed in any way, or files have been added or removed from the project unexpectedly. To do this, you require a private key for signing and a matching public key for verifying.
 
-== Lab Guide: Hands-On Tasks
+== Lab guide: Hands-on tasks
 
 **The Workflow for Signing Ansible Automation Platform (AAP) Projects:**
 
@@ -194,6 +194,6 @@ ade install --editable /home/rhel/myansibleproject/collections/ansible_collectio
 
 
 ---
-== Next Steps
+== Next steps
 
 You have successfully signed and verified your playbook, this ensured that it can't be tampered with and continue to run unnoticed. Please click the **Next** button below to proceed to the next module.

--- a/content/modules/ROOT/pages/99-conclusion.adoc
+++ b/content/modules/ROOT/pages/99-conclusion.adoc
@@ -21,7 +21,7 @@ _A summary of the Ansible development tools you've learned and resources for con
 
 You have successfully completed the **"Intro to creating automation with the new Ansible Development Tools"** workshop!
 
-=== Join the Ansible Forum
+=== Join the Ansible forum
 
 **Scan** the QR code below to sign up to the Ansible Forum if you haven't yet, if you already have scan anyway and you might get a Badge for completing the workshop if you approach your instructor with your username!
 
@@ -44,9 +44,9 @@ You have reached the end of the *Introduction to Ansible development tools* work
 * **`ansible-creator`** to scaffold new collections and content.
 * **`adt`** (Ansible development tools) for a unified command-line tools management.
 * **`ade`** (Ansible development environment) for managing collection dependencies.
-* **`ansible-lint`** for checking playbooks against best practices.
+* **`ansible-lint`** for checking playbooks against recommended practices.
 * **`ansible-navigator`** for a feature-rich terminal-based user interface to run and test your execution environments.
-* **Ansible Molecule** for robustly testing your collections.
+* **Ansible Molecule** for testing your collections in isolated, reproducible environments.
 
 ---
 

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -21,7 +21,7 @@ Before starting this lab, ensure you have:
 * Basic Ansible and YAML syntax understanding
 * Access to the Red Hat Demo Platform environment
 
-== Lab Structure
+== Lab structure
 
 The following modules are included in this lab:
 
@@ -41,16 +41,16 @@ The following modules are included in this lab:
 .. xref:32-ansible-sign.adoc[Lab 3.2 - Introducing supply chain security with ansible-sign]
 . xref:99-conclusion.adoc[Conclusion]
 
-== Learning Outcomes
+== Learning outcomes
 
 By the end of this workshop, you will be able to:
 
 * Use the **Ansible extension for VS Code** features for a rich editing experience.
 * Learn all the creation tools, including `ansible-creator` to scaffold new collections and content, `adt` (Ansible development tools) for a unified command-line tools management, `ade` (Ansible development environment) for managing collection dependencies and virtual environments and `ansible-navigator` for a feature-rich terminal-based user interface to run and test your execution environments..
-* Test your content with `ansible-lint` for checking playbooks against best practices, `molecule` for robustly testing your collections, `pytest-ansible` for functional testing of your modules, and `tox-ansible` for bringing it all together against in multiple combinations.
+* Test your content with `ansible-lint` for checking playbooks against recommended practices, `molecule` for testing your collections in isolated, reproducible environments, `pytest-ansible` for functional testing of your modules, and `tox-ansible` for bringing it all together in multiple combinations.
 * Deploy to production by packaging your Collection content with `ansible-galaxy` and `ansible-builder`, and applying secure supply chain practices with `ansible-sign`.
 
-== Getting Started
+== Getting started
 
 Begin with xref:00-introduction.adoc[Introduction] to start your adventure. Each module includes detailed instructions, code examples, and verification steps.
 


### PR DESCRIPTION
## Summary

- Convert ~45 headings to sentence case across all 11 content files per Red Hat style guide
- Replace prohibited vague term "robustly" with specific language ("testing in isolated, reproducible environments")
- Replace "best practices" with "recommended practices" (3 occurrences)
- Expand bare "AAP" acronym on first use in `31-ansible-builder.adoc`
- Fix "against in" typo in `index.adoc` learning outcomes
- Remove backticks from heading in `11-vscode-collection.adoc` Task 4

## Test plan

- [ ] Verify Antora build succeeds (`antora --fetch site.yml`)
- [ ] Spot-check headings render correctly in browser
- [ ] Confirm no broken xrefs or navigation links

🤖 Generated with [Claude Code](https://claude.com/claude-code)