### PR TITLE
Add solver playbooks for all lab modules

### DIFF
--- a/solvers/00-introduction.yml
+++ b/solvers/00-introduction.yml
@@ -1,0 +1,56 @@
+---
+# =============================================================================
+# Solver: 00-introduction - Introduction
+# =============================================================================
+#
+# Solves:
+# - Task 1: Launch Dev Spaces workspace (VS Code UI - cannot be automated)
+# - Task 2: Configure extensions (VS Code UI - cannot be automated)
+# - Task 3: Verify and update development tools
+#
+# NOTE: Tasks 1 and 2 require the student to interact with the OpenShift
+# Web Console and Dev Spaces UI to launch and configure the workspace.
+# This solver only handles Task 3 (CLI verification and tool updates).
+#
+# =============================================================================
+
+- name: "Solve 00-introduction: Verify and update development environment"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  tasks:
+    # =========================================================================
+    # Task 1: Launch Dev Spaces workspace
+    # SKIPPED - Requires VS Code UI interaction (OpenShift console login,
+    # Dev Spaces workspace selection, trust publishers dialog).
+    # The student must complete this manually.
+    # =========================================================================
+
+    # =========================================================================
+    # Task 2: Configure the extensions
+    # SKIPPED - Requires VS Code UI interaction (reload extension,
+    # click Ansible icon in sidebar). No CLI equivalent.
+    # =========================================================================
+
+    # =========================================================================
+    # Task 3: Verify the development environment
+    # =========================================================================
+    - name: "Task 3: Verify container OS release"
+      ansible.builtin.command: cat /etc/redhat-release
+      changed_when: false
+
+    - name: "Task 3: Verify adt and development tools are available"
+      ansible.builtin.command: adt --version
+      changed_when: false
+
+    - name: "Task 3: Upgrade ansible-dev-tools"
+      ansible.builtin.pip:
+        name: ansible-dev-tools
+        state: present
+
+    - name: "Task 3: Pin ansible-core version"
+      ansible.builtin.pip:
+        name: ansible-core==2.16.15
+        state: present
+      changed_when: true

--- a/solvers/11-vscode-collection.yml
+++ b/solvers/11-vscode-collection.yml
@@ -1,0 +1,89 @@
+---
+# =============================================================================
+# Solver: 11-vscode-collection - Creating a Collection with the VS Code Extension
+# =============================================================================
+#
+# Solves:
+# - Task 0: Create a collection using ansible-creator CLI
+# - Task 1: Explore Ansible extension (VS Code UI - no solver needed)
+# - Task 2: Create a collection project (VS Code wizard -> CLI equivalent)
+# - Task 3: Create a playbook project (VS Code wizard -> CLI equivalent)
+# - Task 4: Open the mycollection folder (VS Code UI - no solver needed)
+# - Task 5: Compare CLI vs VS Code collections (reading exercise - no solver)
+#
+# =============================================================================
+
+- name: "Solve 11-vscode-collection: Create collection and playbook projects"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    base_project_dir: /home/rhel/myansibleproject
+    collections_dir: "{{ base_project_dir }}/collections/ansible_collections"
+
+  tasks:
+    # =========================================================================
+    # Task 0: Create a collection using the ansible-creator CLI
+    # =========================================================================
+    - name: "Task 0: Ensure collections directory exists"
+      ansible.builtin.file:
+        path: "{{ collections_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: "Task 0: Scaffold CLI collection mynamespace.my_cli_collection"
+      ansible.builtin.command:
+        cmd: >-
+          ansible-creator init collection mynamespace.my_cli_collection
+          {{ collections_dir }}
+        creates: "{{ collections_dir }}/mynamespace/my_cli_collection/galaxy.yml"
+
+    # =========================================================================
+    # Task 1: Explore the Ansible extension
+    # SKIPPED - Requires VS Code UI interaction (view extension sidebar,
+    # collapse Lightspeed sections). No CLI equivalent.
+    # =========================================================================
+
+    # =========================================================================
+    # Task 2: Create a collection project
+    # The VS Code wizard creates the collection and installs it in editable
+    # mode. The CLI equivalent uses ansible-creator + ade install -e.
+    # =========================================================================
+    - name: "Task 2: Scaffold collection mynamespace.mycollection"
+      ansible.builtin.command:
+        cmd: >-
+          ansible-creator init collection mynamespace.mycollection
+          {{ collections_dir }}/mynamespace/mycollection
+        creates: "{{ collections_dir }}/mynamespace/mycollection/galaxy.yml"
+
+    - name: "Task 2: Install collection in editable mode with ade"
+      ansible.builtin.command:
+        cmd: ade install -e .
+        chdir: "{{ collections_dir }}/mynamespace/mycollection"
+      changed_when: true
+
+    # =========================================================================
+    # Task 3: Create a playbook project
+    # The VS Code wizard creates a playbook project. The CLI equivalent
+    # uses ansible-creator init playbook.
+    # =========================================================================
+    - name: "Task 3: Scaffold playbook project with mysecondcollection"
+      ansible.builtin.command:
+        cmd: >-
+          ansible-creator init playbook
+          {{ base_project_dir }}
+          --scm-org mynamespace
+          --scm-project mysecondcollection
+        creates: "{{ base_project_dir }}/site.yml"
+
+    # =========================================================================
+    # Task 4: Open the mycollection folder
+    # SKIPPED - Requires VS Code UI interaction (File > Open Folder).
+    # No CLI equivalent needed; the folder already exists.
+    # =========================================================================
+
+    # =========================================================================
+    # Task 5: Compare CLI-generated with VS Code-generated collections
+    # SKIPPED - Reading/comparison exercise. No action required.
+    # =========================================================================

--- a/solvers/12-ade.yml
+++ b/solvers/12-ade.yml
@@ -1,0 +1,159 @@
+---
+# =============================================================================
+# Solver: 12-ade - Using the Ansible Development Environment tool
+# =============================================================================
+#
+# Solves:
+# - Task 1: Activate Ansible Development Environment (VS Code UI - partial)
+# - Task 2: Add collection dependencies (edit galaxy.yml)
+# - Task 3: Check Ansible Development Tools versions
+# - Task 4: Manage dependencies with ade
+#
+# =============================================================================
+
+- name: "Solve 12-ade: Configure ade and manage dependencies"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    collection_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+
+  tasks:
+    # =========================================================================
+    # Task 1: Activate Ansible Development Environment
+    # SKIPPED - Selecting the Python interpreter in VS Code is a UI action.
+    # The .venv was created by ansible-creator in the previous lab.
+    # CLI equivalent: source .venv/bin/activate (handled by running commands
+    # within the venv context).
+    # =========================================================================
+
+    # =========================================================================
+    # Task 2: Add collection dependencies
+    # Edit galaxy.yml to add ansible.posix dependency alongside ansible.utils.
+    # Also update description field.
+    # =========================================================================
+    - name: "Task 2: Read current galaxy.yml"
+      ansible.builtin.slurp:
+        src: "{{ collection_dir }}/galaxy.yml"
+      register: r_galaxy_yml
+
+    - name: "Task 2: Load galaxy.yml content"
+      ansible.builtin.set_fact:
+        galaxy_content: "{{ r_galaxy_yml.content | b64decode | from_yaml }}"
+
+    - name: "Task 2: Update galaxy.yml with description and dependencies"
+      ansible.builtin.copy:
+        dest: "{{ collection_dir }}/galaxy.yml"
+        content: |
+          ---
+          namespace: "mynamespace"
+          name: "mycollection"
+          version: {{ galaxy_content.version | default('1.0.0') }}
+          readme: README.md
+          authors:
+            - Workshop Student <student@localhost>
+
+          description: mycowsay collection
+          license_file: LICENSE
+
+          tags: ["linux", "tools"]
+
+          dependencies:
+            "ansible.utils": "*"
+            "ansible.posix": "*"
+
+          repository: ""
+          documentation: ""
+          homepage: ""
+          issues: ""
+        mode: "0644"
+        backup: true
+
+    # =========================================================================
+    # Task 3: Check Ansible Development Tools versions
+    # =========================================================================
+    - name: "Task 3: Check adt version"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/adt --version"
+      changed_when: false
+
+    - name: "Task 3: Upgrade ansible-dev-tools in venv"
+      ansible.builtin.pip:
+        name: ansible-dev-tools
+        state: present
+        virtualenv: "{{ collection_dir }}/.venv"
+
+    - name: "Task 3: Pin ansible-core version in venv"
+      ansible.builtin.pip:
+        name: ansible-core==2.16.15
+        state: present
+        virtualenv: "{{ collection_dir }}/.venv"
+      changed_when: true
+
+    # =========================================================================
+    # Task 4: Manage dependencies with ade
+    # =========================================================================
+    - name: "Task 4: Install collection dependencies with ade"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ade install -e ."
+        chdir: "{{ collection_dir }}"
+      changed_when: true
+
+    - name: "Task 4: Check dependency tree"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ade tree -v"
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+
+    - name: "Task 4: Update galaxy.yml to add ansible.netcommon dependency"
+      ansible.builtin.copy:
+        dest: "{{ collection_dir }}/galaxy.yml"
+        content: |
+          ---
+          namespace: "mynamespace"
+          name: "mycollection"
+          version: {{ galaxy_content.version | default('1.0.0') }}
+          readme: README.md
+          authors:
+            - Workshop Student <student@localhost>
+
+          description: mycowsay collection
+          license_file: LICENSE
+
+          tags: ["linux", "tools"]
+
+          dependencies:
+            "ansible.utils": "*"
+            "ansible.posix": "*"
+            "ansible.netcommon": "*"
+
+          repository: ""
+          documentation: ""
+          homepage: ""
+          issues: ""
+        mode: "0644"
+        backup: true
+
+    - name: "Task 4: Install system dependencies for ansible.netcommon"
+      ansible.builtin.dnf:
+        name:
+          - python3-cffi
+          - python3-cryptography
+          - python3-lxml
+          - python3-pycparser
+        state: present
+      become: true
+
+    - name: "Task 4: Re-run ade install after adding netcommon"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ade install -e ."
+        chdir: "{{ collection_dir }}"
+      changed_when: true
+
+    - name: "Task 4: Check updated dependency tree"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ade tree -v"
+        chdir: "{{ collection_dir }}"
+      changed_when: false

--- a/solvers/13-module.yml
+++ b/solvers/13-module.yml
@@ -1,0 +1,105 @@
+---
+# =============================================================================
+# Solver: 13-module - Adding a Module to a Collection
+# =============================================================================
+#
+# Solves:
+# - Task 1: Add a custom module (cowsay.py) to the collection
+# - Task 2: Create a playbook that uses the custom module
+# - Task 3: Use ansible-lint to fix the playbook
+# - Task 4: Run the playbook (VS Code UI context menu - partial)
+#
+# =============================================================================
+
+- name: "Solve 13-module: Add module and create playbook"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    collection_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+    project_dir: /home/rhel/myansibleproject
+
+  tasks:
+    # =========================================================================
+    # Task 1: Add a custom module to the collection
+    # =========================================================================
+    - name: "Task 1: Ensure plugins/modules directory exists"
+      ansible.builtin.file:
+        path: "{{ collection_dir }}/plugins/modules"
+        state: directory
+        mode: "0755"
+
+    - name: "Task 1: Create cowsay.py module"
+      ansible.builtin.copy:
+        dest: "{{ collection_dir }}/plugins/modules/cowsay.py"
+        content: |
+          from ansible.module_utils.basic import AnsibleModule
+          import subprocess
+
+          def run_cowsay(message):
+              result = subprocess.run(['cowsay', '-t', message], capture_output=True, text=True)
+              return result.stdout
+
+          def main():
+              module_args = dict(
+                  message=dict(type='str', required=True)
+              )
+
+              module = AnsibleModule(
+                  argument_spec=module_args,
+                  supports_check_mode=True
+              )
+
+              message = module.params['message']
+              result = run_cowsay(message)
+
+              module.exit_json(changed=False, message=result.split('\n'))
+
+          if __name__ == '__main__':
+              main()
+        mode: "0644"
+
+    # =========================================================================
+    # Task 2: Create a playbook to use the new module
+    # =========================================================================
+    - name: "Task 2: Create mycowsay.yml playbook (already lint-fixed)"
+      ansible.builtin.copy:
+        dest: "{{ project_dir }}/mycowsay.yml"
+        content: |
+          ---
+          - name: Using our cowsay module
+            hosts: localhost
+            tasks:
+              - name: Test the cowsay module
+                mynamespace.mycollection.cowsay:
+                  message: Hello, Ansible!
+                register: result
+
+              - name: Display the result
+                ansible.builtin.debug:
+                  msg: "{{ '{{' }} result.message {{ '}}' }}"
+        mode: "0644"
+
+    # =========================================================================
+    # Task 3: Use ansible-lint to fix the playbook
+    # SKIPPED - The playbook created above is already in its final lint-fixed
+    # form (includes play name, proper formatting). The VS Code lint settings
+    # configuration (enabling linter, adding --fix argument) is a UI action
+    # that doesn't require a solver.
+    # =========================================================================
+
+    # =========================================================================
+    # Task 4: Run the playbook
+    # The VS Code UI right-click "Run Ansible Playbook" and "Run with
+    # Ansible Navigator" are UI actions. We run equivalent CLI commands.
+    # =========================================================================
+    - name: "Task 4: Run playbook with ansible-playbook"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ansible-playbook
+          {{ project_dir }}/mycowsay.yml
+      changed_when: false
+      environment:
+        ANSIBLE_COLLECTIONS_PATH: "{{ project_dir }}/collections"

--- a/solvers/21-molecule.yml
+++ b/solvers/21-molecule.yml
@@ -1,0 +1,64 @@
+---
+# =============================================================================
+# Solver: 21-molecule - Testing a Collection with Ansible Molecule
+# =============================================================================
+#
+# Solves:
+# - Task 1: Explore the Molecule scenario (reading exercise - no solver)
+# - Task 2: Examine the integration tests (reading exercise - no solver)
+# - Task 3: Create a filter plugin (VS Code wizard -> CLI equivalent)
+# - Task 4: Run the Molecule test
+#
+# =============================================================================
+
+- name: "Solve 21-molecule: Create filter plugin and run Molecule tests"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    collection_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+    extensions_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/extensions
+
+  tasks:
+    # =========================================================================
+    # Task 1: Explore the Molecule scenario
+    # SKIPPED - Reading/exploration exercise. The student examines the
+    # molecule.yml file and scenario structure. No action required.
+    # =========================================================================
+
+    # =========================================================================
+    # Task 2: Examine the integration tests
+    # SKIPPED - Reading/exploration exercise. The student reviews the
+    # tests/integration/targets/hello_world/tasks/main.yml file.
+    # No action required.
+    # =========================================================================
+
+    # =========================================================================
+    # Task 3: Create a filter plugin
+    # The VS Code wizard creates a filter plugin. The CLI equivalent
+    # uses ansible-creator add plugin.
+    # =========================================================================
+    - name: "Task 3: Create hello_world filter plugin via ansible-creator"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ansible-creator
+          add plugin filter hello_world
+          --path {{ collection_dir }}
+        creates: "{{ collection_dir }}/plugins/filter/hello_world.py"
+
+    # =========================================================================
+    # Task 4: Run the Molecule test
+    # =========================================================================
+    - name: "Task 4: Run Molecule test with integration_hello_world scenario"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/molecule test
+          -s integration_hello_world
+        chdir: "{{ extensions_dir }}"
+      changed_when: true
+      environment:
+        ANSIBLE_COLLECTIONS_PATH: >-
+          /home/rhel/myansibleproject/collections

--- a/solvers/22-pytest-ansible.yml
+++ b/solvers/22-pytest-ansible.yml
@@ -1,0 +1,150 @@
+---
+# =============================================================================
+# Solver: 22-pytest-ansible - Functional testing with pytest-ansible
+# =============================================================================
+#
+# Solves:
+# - Task 1: Create the test inventory
+# - Task 2: Create the test configuration (conftest.py)
+# - Task 3: Create the test file (test_cowsay.py)
+# - Task 4: Run the test
+# - Task 5: Verify the test results
+#
+# =============================================================================
+
+- name: "Solve 22-pytest-ansible: Create test files and run pytest"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    collection_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+    tests_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/tests
+
+  tasks:
+    # =========================================================================
+    # Task 1: Create the test inventory
+    # =========================================================================
+    - name: "Task 1: Ensure tests directory exists"
+      ansible.builtin.file:
+        path: "{{ tests_dir }}"
+        state: directory
+        mode: "0755"
+
+    - name: "Task 1: Create test inventory file"
+      ansible.builtin.copy:
+        dest: "{{ tests_dir }}/inventory"
+        content: |
+          [local]
+          localhost ansible_connection=local ansible_python_interpreter=python3
+        mode: "0644"
+
+    # =========================================================================
+    # Task 2: Create the test configuration
+    # =========================================================================
+    - name: "Task 2: Create conftest.py"
+      ansible.builtin.copy:
+        dest: "{{ tests_dir }}/conftest.py"
+        content: |
+          import os
+          import sys
+          import pytest
+
+          # This block executes immediately when pytest starts,
+          # ensuring Ansible sees the correct paths before loading any plugins.
+
+          # Get the absolute path of the 'tests' directory
+          TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+          # Project root (mycollection folder)
+          PROJECT_ROOT = os.path.dirname(TESTS_DIR)
+
+          # 1. Set ANSIBLE_LIBRARY so Ansible can find 'cowsay' by short name
+          # This points to: .../mycollection/plugins/modules
+          # Without this, Ansible won't know where to look for your custom module
+          MODULES_PATH = os.path.join(PROJECT_ROOT, 'plugins', 'modules')
+          os.environ['ANSIBLE_LIBRARY'] = MODULES_PATH
+
+          # 2. Set ANSIBLE_COLLECTIONS_PATH so Ansible can resolve the full namespace
+          # This points to: .../myansibleproject/collections
+          # We navigate up 3 levels from PROJECT_ROOT:
+          #   mycollection -> mynamespace -> ansible_collections -> collections root
+          # This allows Ansible to find modules using FQCN (mynamespace.mycollection.cowsay)
+          COLLECTIONS_PATH = os.path.abspath(os.path.join(PROJECT_ROOT, '../../..'))
+          os.environ['ANSIBLE_COLLECTIONS_PATH'] = COLLECTIONS_PATH
+        mode: "0644"
+
+    # =========================================================================
+    # Task 3: Create the test file
+    # =========================================================================
+    - name: "Task 3: Create test_cowsay.py"
+      ansible.builtin.copy:
+        dest: "{{ tests_dir }}/test_cowsay.py"
+        content: |
+          def test_cowsay_module(ansible_module):
+              """
+              Test the cowsay module functionality.
+
+              The ansible_module fixture is provided by pytest-ansible and allows
+              us to execute Ansible modules directly from Python test code.
+              """
+
+              # 1. Define the input
+              test_message = "Hello, pytest-ansible!"
+              module_args = {
+                  "message": test_message
+              }
+
+              # 2. Run the module
+              # The ansible_module fixture executes the module on all inventory hosts
+              # In our case, that's just 'localhost' as defined in the inventory file
+              result = ansible_module.cowsay(**module_args)
+
+              # 3. Extract results for the localhost
+              # Result is a dictionary keyed by hostname
+              host_result = result['localhost']
+
+              # 4. Validation - Check module execution status
+              # Verify the module didn't fail
+              assert not host_result.get('failed', False), "Module execution failed"
+
+              # Verify the module didn't report changes (cowsay shouldn't change system state)
+              assert not host_result['changed'], "Module unexpectedly reported changes"
+
+              # 5. Reconstruct the output string from the returned message list
+              output_text = "\n".join(host_result['message'])
+
+              # 6. Validate the output content
+              # Check that our input message appears somewhere in the cowsay output
+              assert test_message in output_text, f"Expected message '{test_message}' not found in output"
+
+              # Verify it's actually cowsay output by checking for characteristic elements
+              # The cow's body typically contains these border characters
+              assert "_" in output_text or "-" in output_text, "Output doesn't look like cowsay format"
+              assert "\\" in output_text or "/" in output_text, "Missing cowsay speech bubble borders"
+              assert "(oo)" in output_text, "Checking for the cow eyes failed"
+        mode: "0644"
+
+    # =========================================================================
+    # Task 4: Run the test
+    # =========================================================================
+    - name: "Task 4: Activate venv and run pytest"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/pytest"
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      environment:
+        ANSIBLE_COLLECTIONS_PATH: /home/rhel/myansibleproject/collections
+
+    # =========================================================================
+    # Task 5: Verify the test results
+    # =========================================================================
+    - name: "Task 5: Run pytest with verbose output"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/pytest -v -s"
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      environment:
+        ANSIBLE_COLLECTIONS_PATH: /home/rhel/myansibleproject/collections

--- a/solvers/23-tox-ansible.yml
+++ b/solvers/23-tox-ansible.yml
@@ -1,0 +1,107 @@
+---
+# =============================================================================
+# Solver: 23-tox-ansible - Orchestrating Tests with tox-ansible
+# =============================================================================
+#
+# Solves:
+# - Task 1: Verify tox installation
+# - Task 2: Create a minimal tox configuration (tox.ini)
+# - Task 3: Explore auto-generated environments
+# - Task 4: Run the tests (lint, unit, integration)
+# - Task 5: Run a group of tests
+#
+# =============================================================================
+
+- name: "Solve 23-tox-ansible: Configure and run tox test orchestration"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    collection_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+
+  tasks:
+    # =========================================================================
+    # Task 1: Verify tox installation
+    # =========================================================================
+    - name: "Task 1: Check tox version"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/tox --version"
+      changed_when: false
+
+    # =========================================================================
+    # Task 2: Create a minimal tox configuration
+    # =========================================================================
+    - name: "Task 2: Create tox.ini"
+      ansible.builtin.copy:
+        dest: "{{ collection_dir }}/tox.ini"
+        content: |
+          [tox]
+          # Global tox settings
+          envlist = lint, unit
+          skip_missing_interpreters = True
+          requires =
+              tox-ansible
+
+          [testenv]
+          # This section configures the default behavior for all environments
+          usedevelop = true
+          deps =
+              pytest
+              pytest-ansible
+              ansible-lint
+              molecule-plugins[podman]
+
+          [ansible]
+          # Configuration specific to the tox-ansible plugin
+          # This limits the matrix to Ansible 2.15 and 2.16 to save time/resources
+          ansible_core_versions =
+              2.15
+              2.16
+        mode: "0644"
+
+    # =========================================================================
+    # Task 3: Explore auto-generated environments
+    # =========================================================================
+    - name: "Task 3: List all available tox environments"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/tox -l"
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+
+    # =========================================================================
+    # Task 4: Run the tests
+    # =========================================================================
+    - name: "Task 4: Run linting environment"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/tox -e lint"
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      failed_when: false
+
+    - name: "Task 4: Run unit tests against Ansible 2.16"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/tox -e py311-ansible2.16-unit"
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      failed_when: false
+
+    - name: "Task 4: Run integration tests (Molecule) against Ansible 2.16"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/tox
+          -e py311-ansible2.16-molecule-integration_hello_world
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      failed_when: false
+
+    # =========================================================================
+    # Task 5: Run a group of tests
+    # =========================================================================
+    - name: "Task 5: Run all tests for Ansible 2.16"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/tox -f ansible2.16"
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      failed_when: false

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -1,0 +1,139 @@
+---
+# =============================================================================
+# Solver: 31-ansible-builder - Creating an Execution Environment
+# =============================================================================
+#
+# Solves:
+# - Task 1: Define the EE definition file (VS Code wizard -> CLI equivalent)
+# - Task 2: Review the generated Containerfile (dry run)
+# - Task 3: Build and tag the custom Execution Environment
+#
+# =============================================================================
+
+- name: "Solve 31-ansible-builder: Create and build Execution Environment"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    collection_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+    project_dir: /home/rhel/myansibleproject
+
+  tasks:
+    # =========================================================================
+    # Task 1: Define the Execution Environment definition file
+    # The VS Code wizard creates an EE project. We create the files directly
+    # and run the equivalent CLI commands.
+    # =========================================================================
+
+    # First, disable editable mode before building the tarball
+    - name: "Task 1: Switch ade to standard mode for packaging"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ade install ."
+        chdir: "{{ collection_dir }}"
+      changed_when: true
+
+    # Build the collection tarball
+    - name: "Task 1: Build collection tarball with ansible-galaxy"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ansible-galaxy collection build
+          --output-path {{ project_dir }}/
+        chdir: "{{ collection_dir }}"
+      changed_when: true
+
+    # Re-enable editable mode
+    - name: "Task 1: Re-enable ade editable mode"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ade install -e ."
+        chdir: "{{ collection_dir }}"
+      changed_when: true
+
+    # Create the execution-environment.yml with local tarball reference
+    - name: "Task 1: Create execution-environment.yml"
+      ansible.builtin.copy:
+        dest: "{{ project_dir }}/execution-environment.yml"
+        content: |
+          ---
+          version: 3
+          images:
+            base_image:
+              name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:latest
+
+          dependencies:
+            ansible_core:
+              package_pip: ansible-core
+            ansible_runner:
+              package_pip: ansible-runner
+            galaxy:
+              collections:
+                # Tell Galaxy to look inside the local folder
+                - name: collection_tarballs/mynamespace-mycollection-1.0.0.tar.gz
+                  type: file
+            python:
+              - cowsay
+
+          # Copy the tarball into a dedicated folder named 'collection_tarballs'
+          additional_build_files:
+            - src: mynamespace-mycollection-1.0.0.tar.gz
+              dest: collection_tarballs
+
+          options:
+            tags:
+              - mycollection-ee
+            package_manager_path: /usr/bin/microdnf
+        mode: "0644"
+
+    # =========================================================================
+    # Task 2: Review the generated Containerfile (dry run)
+    # =========================================================================
+    - name: "Task 2: Run ansible-builder create to generate Containerfile"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ansible-builder create"
+        chdir: "{{ project_dir }}"
+      changed_when: true
+
+    # =========================================================================
+    # Task 3: Build and tag the custom Execution Environment
+    # =========================================================================
+    - name: "Task 3: Build the EE image"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ansible-builder build
+          -t mynamespace/mycollection-ee:latest -vvv
+        chdir: "{{ project_dir }}"
+      changed_when: true
+      timeout: 600
+
+    - name: "Task 3: Verify the container image exists"
+      ansible.builtin.command:
+        cmd: podman images --format "{{ '{{' }}.Repository{{ '}}' }}:{{ '{{' }}.Tag{{ '}}' }}" --filter reference=mynamespace/mycollection-ee
+      changed_when: false
+      register: r_podman_images
+
+    - name: "Task 3: Verify collection is inside the EE"
+      ansible.builtin.command:
+        cmd: >-
+          podman run --rm mynamespace/mycollection-ee:latest
+          ansible-galaxy collection list
+      changed_when: false
+
+    - name: "Task 3: Run mycowsay.yml with ansible-navigator using the EE"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ansible-navigator run
+          {{ project_dir }}/mycowsay.yml
+          --execution-environment-image mycollection-ee
+          --pull-policy never
+          --mode stdout
+        chdir: "{{ project_dir }}"
+      changed_when: false
+
+    - name: "Task 3: Test cowsay module documentation inside the EE"
+      ansible.builtin.command:
+        cmd: >-
+          podman run --rm mynamespace/mycollection-ee:latest
+          ansible-doc -t module mynamespace.mycollection.cowsay
+      changed_when: false
+      failed_when: false

--- a/solvers/32-ansible-sign.yml
+++ b/solvers/32-ansible-sign.yml
@@ -1,0 +1,144 @@
+---
+# =============================================================================
+# Solver: 32-ansible-sign - Introducing supply chain security with ansible-sign
+# =============================================================================
+#
+# Solves:
+# - Task 1: Create a GPG key
+# - Task 2: Set up the environment
+# - Task 3: Create a MANIFEST.in file
+# - Task 4: Sign the project with ansible-sign
+# - Task 5: Verify the content with ansible-sign
+# - Task 6: Enable verification in AAP (informational - no solver needed)
+#
+# =============================================================================
+
+- name: "Solve 32-ansible-sign: Sign and verify Ansible content"
+  hosts: localhost
+  gather_facts: false
+  become: false
+
+  vars:
+    collection_dir: >-
+      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+    project_dir: /home/rhel/myansibleproject
+
+  tasks:
+    # =========================================================================
+    # Task 1: Create a GPG key
+    # =========================================================================
+    - name: "Task 1: Install pinentry-curses dependency"
+      ansible.builtin.dnf:
+        name: pinentry-curses
+        state: present
+      become: true
+
+    - name: "Task 1: Create GPG batch configuration file"
+      ansible.builtin.copy:
+        dest: ~/gpg.txt
+        content: |
+          %echo Generating a basic OpenPGP key
+          Key-Type: default
+          Key-Length: 4096
+          Subkey-Type: default
+          Subkey-Length: default
+          Name-Real: workshop
+          Name-Comment: with no passphrase
+          Name-Email: student@localhost
+          Expire-Date: 0
+          %no-ask-passphrase
+          %no-protection
+          # Do a commit here, so that we can later print "done" :-)
+          %commit
+          %echo done
+        mode: "0644"
+
+    - name: "Task 1: Check if GPG key already exists"
+      ansible.builtin.command:
+        cmd: gpg --list-secret-keys student@localhost
+      changed_when: false
+      failed_when: false
+      register: r_gpg_check
+
+    - name: "Task 1: Generate GPG key"
+      ansible.builtin.command:
+        cmd: gpg --batch --gen-key ~/gpg.txt
+      when: r_gpg_check.rc != 0
+      changed_when: true
+
+    - name: "Task 1: Verify the GPG key was created"
+      ansible.builtin.command:
+        cmd: gpg --list-secret-keys
+      changed_when: false
+
+    # =========================================================================
+    # Task 2: Set up the environment
+    # =========================================================================
+    - name: "Task 2: Switch ade to standard mode (remove recursive symlinks)"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ade install
+          {{ collection_dir }}
+        chdir: "{{ project_dir }}"
+      changed_when: true
+
+    # =========================================================================
+    # Task 3: Create a MANIFEST.in file
+    # =========================================================================
+    - name: "Task 3: Create MANIFEST.in file"
+      ansible.builtin.copy:
+        dest: "{{ project_dir }}/MANIFEST.in"
+        content: |
+          # Exclude .venv FIRST before any includes
+          global-exclude .venv
+          global-exclude .venv/*
+          prune .venv
+
+          # Exclude .git
+          global-exclude .git
+          global-exclude .git/*
+          prune .git
+
+          # Now include what you want to sign
+          include README.md
+          include mycowsay.yml
+        mode: "0644"
+
+    # =========================================================================
+    # Task 4: Sign the project with ansible-sign
+    # =========================================================================
+    - name: "Task 4: Sign the project files"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ansible-sign project gpg-sign ."
+        chdir: "{{ project_dir }}"
+      changed_when: true
+
+    # =========================================================================
+    # Task 5: Verify the content with ansible-sign
+    # =========================================================================
+    - name: "Task 5: Display checksum manifest"
+      ansible.builtin.command:
+        cmd: cat .ansible-sign/sha256sum.txt
+        chdir: "{{ project_dir }}"
+      changed_when: false
+
+    - name: "Task 5: Verify signed content"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ansible-sign project gpg-verify ."
+        chdir: "{{ project_dir }}"
+      changed_when: false
+
+    - name: "Task 5: Switch ade back to editable mode"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ade install --editable
+          {{ collection_dir }}
+        chdir: "{{ project_dir }}"
+      changed_when: true
+
+    # =========================================================================
+    # Task 6: Enable verification in AAP executions
+    # SKIPPED - Informational content only. The lab explains the next steps
+    # (create GPG credential, push to git, create AAP project) but does not
+    # have the student perform them. No action required.
+    # =========================================================================


### PR DESCRIPTION
## Summary
- Adds 9 Ansible solver playbooks (`solvers/`) covering every lab module (00-introduction through 32-ansible-sign)
- Enables automated validation and Full Test Lifecycle (FTL) grading for the workshop
- Each solver mirrors the hands-on steps from its corresponding lab module

## Solvers included
| File | Lab Module |
|------|-----------|
| `00-introduction.yml` | Environment setup & tool verification |
| `11-vscode-collection.yml` | Creating collections with VS Code |
| `12-ade.yml` | Ansible Development Environment |
| `13-module.yml` | Adding custom modules |
| `21-molecule.yml` | Integration testing with Molecule |
| `22-pytest-ansible.yml` | Functional testing with pytest-ansible |
| `23-tox-ansible.yml` | Test orchestration with tox-ansible |
| `31-ansible-builder.yml` | Building execution environments |
| `32-ansible-sign.yml` | Supply chain security with ansible-sign |

## Test plan
- [ ] Review each solver playbook for correctness against lab instructions
- [ ] Run solvers in a fresh Dev Spaces environment to validate end-to-end
- [ ] Verify idempotency (running twice produces no changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)