### PR TITLE
Normalize module structure and flow for consistency

### DIFF
--- a/content/modules/ROOT/pages/00-introduction.adoc
+++ b/content/modules/ROOT/pages/00-introduction.adoc
@@ -65,7 +65,9 @@ Before we begin, here are some tips to improve your lab experience:
 
 * The lab consists of several **Modules**. Each module contains one or more **Tasks**. When you finish a module, click the **Next** button at the bottom of the instructions sidebar to proceed.
 
-== Task 1: Launch the Dev Spaces workspace
+== Lab guide: Hands-on tasks
+
+=== Task 1: Launch the Dev Spaces workspace
 
 . Launch the link:{openshift_cluster_console_url}[OpenShift Web Console^]
 . Select the **htpasswd_provider** button and use the credentials provided in the xref:environment-details.adoc[Environment Details] page to log in to the OpenShift console
@@ -91,7 +93,7 @@ image::11-platform-dev-spaces/intro4.png[Dev Spaces workspace loading screen sho
 +
 image::11-platform-dev-spaces/intro5.png[VS Code interface in Dev Spaces showing Ansible and OpenShift extension icons in the left sidebar,link=self,window=blank]
 
-== Task 2: Configure the extensions
+=== Task 2: Configure the extensions
 
 . Check the **Extensions** section in VS Code, look for the Ansible extension and click the blue **Reload Window** button to update to the latest version
 +
@@ -101,7 +103,7 @@ image::vscode-devtools-extension-reload.png[Reload extensions in VS Code,link=se
 +
 image::11-platform-dev-spaces/intro6.png[Ansible extension interface in VS Code showing available Ansible development tools,link=self,window=blank]
 
-== Task 3: Verify the development environment
+=== Task 3: Verify the development environment
 
 The majority of the exercises in this lab will be performed using the VS Code terminal.
 
@@ -138,7 +140,7 @@ pip3 install --upgrade ansible-dev-tools
 pip3 install ansible-core==2.16.15
 ----
 
-== Conclusion
+== Summary
 
 In this module, you have:
 
@@ -148,6 +150,6 @@ In this module, you have:
 
 This foundation prepares you for the remaining labs where you will create, test, and deploy Ansible automation content.
 
-== Contributing to this lab
+== Next steps
 
-If you see an error in this lab, fork and submit a pull request against link:https://github.com/rhpds/ansible-dev-tools-showroom[https://github.com/rhpds/ansible-dev-tools-showroom^]
+Please click the **Next** button below to proceed to xref:11-vscode-collection.adoc[Lab 1.1 - Creating a Collection with the VS Code Extension].

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -12,18 +12,10 @@ _A guide to using the Ansible extension for Visual Studio Code to scaffold a new
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
+* **Prepares you for:** xref:12-ade.adoc[Lab 1.2 - Using the Ansible Development Environment tool (ade)]
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:**  
+* **Estimated Time:** 20 minutes
 ****
-
-== Lab briefing
-
-`ansible-creator` is a Command-Line Interface (CLI) tool designed for effortlessly scaffolding all your Ansible content. Whether you are initializing an Ansible collection or creating the framework for specific plugins, this tool streamlines the process with efficiency and precision based on your requirements.
-
-`ansible-creator` is also integrated into the VS Code user interface through the Ansible extension for VS Code for even a smoother experience when developing content.
-
-In this exercise, you will create an Ansible collection and a playbook using the Ansible extension's wizard in VS Code.
 
 == Learning objectives
 
@@ -33,9 +25,16 @@ After completing this module, you will be able to:
 * Use the Ansible VS Code extension to create collection and playbook projects
 * Compare CLI-generated and VS Code-generated collection structures
 
+== Lab briefing
+
+`ansible-creator` is a Command-Line Interface (CLI) tool designed for effortlessly scaffolding all your Ansible content. Whether you are initializing an Ansible collection or creating the framework for specific plugins, this tool streamlines the process with efficiency and precision based on your requirements.
+
+`ansible-creator` is also integrated into the VS Code user interface through the Ansible extension for VS Code for even a smoother experience when developing content.
+
+In this section, you will create an Ansible collection and a playbook using the Ansible extension's wizard in VS Code.
+
 image::Jun-06-2025_at_21.02.34-image.png[VS Code editor inside the lab environment,link=self,window=blank, opts="border"]
 
----
 
 == Lab guide: Hands-on tasks
 
@@ -205,8 +204,15 @@ image::May-06-2025_at_21.58.21-image.png[Scaffolded collection files in the Expl
 . **Same defaults**
 . **Same metadata files**
 
----
+
+== Summary
+
+In this lab, you have:
+
+* Scaffolded a collection using the `ansible-creator` CLI
+* Used the Ansible VS Code extension to create collection and playbook projects
+* Opened and explored the generated collection structure
 
 == Next steps
 
-You have successfully explored how ansible-creator and VS Code work together to scaffold a collection. Please click the **Next** button below to proceed to the next module.
+Please click the **Next** button below to proceed to xref:12-ade.adoc[Lab 1.2 - Using the Ansible Development Environment tool (ade)].

--- a/content/modules/ROOT/pages/12-ade.adoc
+++ b/content/modules/ROOT/pages/12-ade.adoc
@@ -12,10 +12,18 @@ _A guide to exploring what `ansible-creator` and `ade` (Ansible Dev Environment)
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
+* **Prepares you for:** xref:13-module.adoc[Lab 1.3 - Adding a Module to a Collection]
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 
+* **Estimated Time:** 20 minutes
 ****
+
+== Learning objectives
+
+After completing this module, you will be able to:
+
+* Customize the `galaxy.yml` metadata for your collection
+* Use `ade` to install and manage collection dependencies
+* Understand how `ade` tracks Python and system-level requirements
 
 == Lab briefing
 
@@ -31,19 +39,10 @@ Ansible Dev Environment (`ade`) is a management tool for Ansible content develop
 - Providing configurable workspace isolation
 
 
-In this challenge, you will explore the content that was automatically generated for the collection you just created and learn how to customize your requirements using `ade`.
-
-== Learning objectives
-
-After completing this module, you will be able to:
-
-* Customize the `galaxy.yml` metadata for your collection
-* Use `ade` to install and manage collection dependencies
-* Understand how `ade` tracks Python and system-level requirements
+In this section, you will explore the content that was automatically generated for the collection you just created and learn how to customize your requirements using `ade`.
 
 image::May-06-2025_at_21.58.21-image.png[Scaffolded collection files in the Explorer view,link=self,window=blank, opts="border"]
 
----
 
 == Lab guide: Hands-on tasks
 
@@ -221,10 +220,15 @@ sudo dnf install -y python3-cffi python3-cryptography python3-lxml python3-pycpa
 
 NOTE: Remember the "Install collection from source code (editable mode)" option you selected during the Collection creation wizard? That option used `ade install -e` to automatically create the virtual environment (`.venv`) that you are using now.
 
----
+== Summary
 
+In this lab, you have:
+
+* Customized the `galaxy.yml` metadata for your collection
+* Used `ade` to install and manage collection dependencies
+* Resolved system-level package requirements with `ade`
 
 == Next steps
 
-You have successfully explored how Ansible Dev Tools (`adt`) and Ansible Dev Environment (`ade`) work. Please click the **Next** button below to proceed to the next module.
+Please click the **Next** button below to proceed to xref:13-module.adoc[Lab 1.3 - Adding a Module to a Collection].
 

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -12,14 +12,10 @@ _A guide to adding a custom module to your Ansible collection and using it in a 
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
+* **Prepares you for:** xref:21-molecule.adoc[Lab 2.1 - Testing a Collection with Ansible Molecule]
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:**
+* **Estimated Time:** 15 minutes
 ****
-
-== Lab briefing
-
-In this challenge, you will be adding content in the form of a Ansible **module plugin** to the collection you created, and then using the module for a new playbook, which you will fix with `ansible-lint` before running it with `ansible-navigator`.
 
 == Learning objectives
 
@@ -30,7 +26,10 @@ After completing this module, you will be able to:
 * Use `ansible-lint` to detect and auto-fix playbook issues
 * Run playbooks with both `ansible-playbook` and `ansible-navigator`
 
----
+== Lab briefing
+
+In this section, you will be adding content in the form of a Ansible **module plugin** to the collection you created, and then using the module for a new playbook, which you will fix with `ansible-lint` before running it with `ansible-navigator`.
+
 
 == Lab guide: Hands-on tasks
 
@@ -159,7 +158,15 @@ image::vscode-devtools-cowsay-navigator.png[Viewing task output in Ansible Navig
 
 .   **Exit Ansible Navigator.** **Press** the `ESC` key 3 times to exit the TUI and return to the normal terminal prompt.
 
----
+== Summary
+
+In this lab, you have:
+
+* Added a custom Python module to your Ansible collection
+* Created a playbook that uses the custom module
+* Used `ansible-lint` to detect and auto-fix playbook issues
+* Run the playbook with both `ansible-playbook` and `ansible-navigator`
+
 == Next steps
 
-You have successfully added and tested a custom module in your collection. Please click the **Next** button below to proceed to the next module.
+Please click the **Next** button below to proceed to xref:21-molecule.adoc[Lab 2.1 - Testing a Collection with Ansible Molecule].

--- a/content/modules/ROOT/pages/21-molecule.adoc
+++ b/content/modules/ROOT/pages/21-molecule.adoc
@@ -11,9 +11,9 @@ _A guide to testing your Ansible collection using Ansible Molecule and a pre-con
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
+* **Prepares you for:** xref:22-pytest-ansible.adoc[Lab 2.2 - Functional testing with pytest-ansible]
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 
+* **Estimated Time:** 25 minutes
 ****
 
 == Learning objectives
@@ -27,7 +27,7 @@ After completing this module, you will be able to:
 
 == Lab briefing
 
-In this challenge, you will explore and test the collection you created in previous modules using **Ansible Molecule**.
+In this section, you will explore and test the collection you created in previous modules using **Ansible Molecule**.
 
 Ansible Molecule is a tool designed to aid in developing and testing Ansible playbooks, collections, and roles. It provides support for testing Ansible content across multiple instances, operating systems, and providers.
 
@@ -66,13 +66,10 @@ When you run `molecule test`, it executes these stages in sequence:
 
 This lifecycle ensures your content is tested in a clean, reproducible environment every time.
 
----
 
 == Lab guide: Hands-on tasks
 
 Now, let's explore the test scenario that was automatically added to your collection project.
-
----
 
 
 === Task 1: Explore the Molecule scenario
@@ -109,8 +106,6 @@ image::vscode-devtools-molecule-converge.png[Converge playbook for the Molecule 
 +
 This playbook runs during the **converge** stage of the Molecule lifecycle. It's the "system under test" - the playbook that exercises your collection's functionality. Notice how it references the integration tests that will validate the behavior.
 
----
-
 
 === Task 2: Examine the integration tests
 
@@ -142,8 +137,6 @@ Assertion-based testing is a common pattern in Ansible testing. Think of asserti
 This setup → execute → verify pattern is fundamental to effective testing.
 
 
----
-
 
 === Task 3: Create a filter plugin
 
@@ -172,8 +165,6 @@ image::May-12-2025_at_21.51.02-image.png[Creating a Collection plugin,link=self,
 ====
 The Ansible extension creates the plugin structure automatically, including the skeleton code and proper file placement. In a real development workflow, you would then write tests for this new plugin and verify them with Molecule before considering the feature complete.
 ====
-
----
 
 
 === Task 4: Run the Molecule test
@@ -236,9 +227,16 @@ A passing Molecule test means your collection has been validated in an automated
 * `molecule destroy -s <scenario>` - Tear down the test environment
 ====
 
----
+== Summary
 
-=== Troubleshooting common issues
+In this lab, you have:
+
+* Explored a Molecule test scenario structure and configuration
+* Examined integration test files and assertion-based testing patterns
+* Created a new filter plugin using the Ansible VS Code extension
+* Executed the complete Molecule test lifecycle for an Ansible collection
+
+== Troubleshooting
 
 . **If you see "No such file or directory" errors:**
 +
@@ -281,35 +279,6 @@ Ensure you have network connectivity and that any required Ansible Galaxy collec
 +
 Review the syntax error message carefully. It will point you to the specific file and line number where the issue was detected. Use `ansible-lint` (covered in earlier modules) to catch these issues before running Molecule tests.
 
----
-
-== Summary
-
-In this lab, you have:
-
-* Explored a Molecule test scenario structure and understood its purpose in Ansible development
-* Examined Molecule configuration files (`molecule.yml`) and learned how they define test behavior
-* Reviewed integration test files to understand assertion-based testing patterns
-* Created a new filter plugin using the Ansible VS Code extension
-* Successfully executed the complete Molecule test lifecycle for an Ansible collection
-* Observed how Molecule validates collection functionality automatically through multiple stages
-* Learned troubleshooting techniques for common Molecule issues
-
-Molecule is essential for maintaining high-quality Ansible content. The automated testing approach you've learned ensures that:
-
-* Code changes don't break existing functionality (regression testing)
-* New features work as expected before deployment
-* Your collection behaves consistently across different environments
-* Integration with other Ansible components works correctly
-
-In production environments, these tests run automatically in CI/CD pipelines (such as GitHub Actions, GitLab CI, or Jenkins), ensuring every code change is validated before merging. This "test-driven development" approach catches bugs early when they're cheapest to fix, and gives teams confidence to make changes without fear of breaking things.
-
-The skills you've learned in this module - understanding test scenarios, writing assertions, and running automated tests - are fundamental to professional Ansible development and will serve you well as you build more complex automation solutions.
-
----
-
 == Next steps
 
-You have successfully used Molecule to test your collection. In the next module, you'll explore additional development tools and recommended practices for maintaining production-ready Ansible content. 
-
-Please click the **Next** button below to proceed to the next module.
+Please click the **Next** button below to proceed to xref:22-pytest-ansible.adoc[Lab 2.2 - Functional testing with pytest-ansible].

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -12,9 +12,9 @@ _Learn how to do functional testing for your Ansible content using pytest-ansibl
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
+* **Prepares you for:** xref:23-tox-ansible.adoc[Lab 2.3 - Orchestrating Tests with tox-ansible]
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:**
+* **Estimated Time:** 15 minutes
 ****
 
 == Learning objectives
@@ -36,15 +36,9 @@ pytest-ansible is a pytest plugin that bridges the gap between Python's pytest f
 
 This integration allows you to write fast, isolated tests for Ansible modules, plugins, and other components using familiar Python testing patterns. While Molecule excels at integration testing with real infrastructure, pytest-ansible focuses on functional and unit-level validation of individual Ansible components.
 
-In this lab, you'll learn how to test the custom `cowsay` module you developed earlier using pytest-ansible.
+In this section, you'll learn how to test the custom `cowsay` module you developed earlier using pytest-ansible.
 
-== Lab guide: Hands-on tasks
-
-=== Why pytest-ansible?
-
-pytest-ansible integrates Ansible with pytest by exposing fixtures that allow Ansible content to be executed and inspected as part of standard Python tests.
-
-This is especially useful for:
+pytest-ansible integrates Ansible with pytest by exposing fixtures that allow Ansible content to be executed and inspected as part of standard Python tests. This is especially useful for:
 
 * Custom modules
 * Filter plugins
@@ -53,17 +47,13 @@ This is especially useful for:
 
 These tests run quickly and are well-suited for CI pipelines.
 
----
-
-=== Test scope
-
-In this task, we will test the custom `cowsay` module developed earlier in the collection:
+In this lab, we will test the custom `cowsay` module developed earlier in the collection:
 
 * Module: `mynamespace.mycollection.cowsay`
 * Test type: Functional test
 * Target: Local test host
 
----
+== Lab guide: Hands-on tasks
 
 === Task 1: Create the test inventory
 
@@ -75,7 +65,6 @@ In this task, we will test the custom `cowsay` module developed earlier in the c
 localhost ansible_connection=local ansible_python_interpreter=python3
 ----
 
----
 
 === Task 2: Create the test configuration
 
@@ -121,7 +110,6 @@ The `conftest.py` file is a special pytest configuration file that runs before a
 ====
 
 
----
 
 === Task 3: Create the test file
 
@@ -179,7 +167,6 @@ def test_cowsay_module(ansible_module):
 This test validates both the module's execution (no failures, correct change state) and its output (contains the expected message with cowsay formatting). The assertions check for structural elements that are always present in cowsay output, making the test more reliable than checking for specific ASCII art.
 ====
 
----
 
 === Task 4: Run the test
 
@@ -221,7 +208,6 @@ Results (1.15s):
 NOTE: You might see warnings between the Results and PASSED tests/test_cowsay.py. That's ok. 
 
 
----
 
 === Task 5: Verify the test results
 
@@ -259,9 +245,7 @@ pytest -v -s
 ** The test validated the cowsay-specific formatting
 
 
----
-
-=== Molecule vs pytest-ansible
+== Molecule vs pytest-ansible
 
 [cols="1,3",options="header"]
 |===
@@ -275,33 +259,18 @@ pytest -v -s
 
 Molecule validates *how content behaves in a system context*, while pytest-ansible validates *how individual components behave in isolation*.
 
----
-
-=== When to use each tool
-
-* Use Molecule when testing:
-** Roles
-** Complex interactions
-** OS-specific behavior
-
-* Use pytest-ansible when testing:
-** Custom modules
-** Plugins
-** Small, fast logic checks
-
 Both tools complement each other and are commonly used together in professional Ansible content pipelines.
 
----
+== Summary
 
-=== Key takeaways
+In this lab, you have:
 
-* Molecule ensures your automation works in real environments.
-* pytest-ansible ensures your building blocks behave correctly.
-* Using both provides layered confidence in your Ansible content.
+* Set up pytest-ansible for functional testing of Ansible modules
+* Written a Python test file that validates module behavior
+* Configured `conftest.py` for module and collection path resolution
+* Used pytest debugging flags to interpret test output
 
----
-
-=== Troubleshooting
+== Troubleshooting
 
 If tests fail, use these debugging techniques:
 
@@ -323,3 +292,7 @@ Common issues:
 * *Module not found*: Check that `conftest.py` paths are correct and your collection structure matches expectations
 * *Assertion failures*: Use `-s` to see the actual output and verify what the module returned
 * *Import errors*: Ensure pytest-ansible is installed and your Python environment is activated
+
+== Next steps
+
+Please click the **Next** button below to proceed to xref:23-tox-ansible.adoc[Lab 2.3 - Orchestrating Tests with tox-ansible].

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -178,6 +178,15 @@ tox -f ansible2.16
 This command tells tox: "Run every test environment that includes 'ansible2.16' in its name." This effectively runs your Unit tests AND Molecule tests for that version in one go.
 
 
+== Summary
+
+In this lab, you have:
+
+* Configured `tox-ansible` to auto-discover test environments
+* Explored the auto-generated test matrix from a minimal configuration
+* Run linting, unit, and integration tests through a unified `tox` interface
+* Targeted specific Ansible versions and test types using tox factors
+
 == Troubleshooting
 
 **"InterpreterNotFound"**
@@ -188,16 +197,6 @@ If `tox -l` returns nothing or very few items:
 1. Ensure you are in the directory containing `galaxy.yml`.
 2. Ensure you actually created the `tests/unit` folder or `molecule` scenarios in previous modules. The plugin only generates environments for tests that actually exist.
 
-
-== Summary
-
-In this lab, you utilized the **tox-ansible** plugin to dramatically simplify test automation.
-
-* **Orchestration:** You replaced manual `ansible-lint`, `pytest`, and `molecule` commands with a unified `tox` interface.
-* **Auto-discovery:** You learned how the plugin scans your project to generate the test matrix automatically.
-* **Matrix Testing:** You validated your code against specific Ansible Core versions (2.15, 2.16) without managing the dependencies manually.
-
 == Next steps
 
-With your testing pipeline automated, you are ready to package your work.
-Click the **Next** button below to proceed to xref:31-ansible-builder.adoc[Lab 3.1 - Creating an Execution Environment with ansible-builder].
+Please click the **Next** button below to proceed to xref:31-ansible-builder.adoc[Lab 3.1 - Creating an Execution Environment with ansible-builder].

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -11,9 +11,9 @@ _A guide to automating the creation and customization of containerized execution
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** Launching OpenShift Dev Spaces
+* **Prepares you for:** xref:32-ansible-sign.adoc[Lab 3.2 - Introducing supply chain security with ansible-sign]
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 10 - 20 minutes
+* **Estimated Time:** 25 minutes
 ****
 
 == Learning objectives
@@ -330,7 +330,16 @@ podman run mynamespace/mycollection-ee:latest ansible-doc -t module mynamespace.
 +
 IMPORTANT: This command should display the documentation for your custom module, but we didn't add the corresponding metadata blocks! We will leave it to you as an optional task to research and fix this issue if you have time after finishing the lab!
 
----
+== Summary
+
+In this lab, you have:
+
+* Defined an execution environment using `execution-environment.yml`
+* Packaged a collection with `ansible-galaxy collection build`
+* Inspected the generated Containerfile with `ansible-builder create`
+* Built and tagged a custom execution environment image
+* Tested the execution environment with `podman` and `ansible-navigator`
+
 == Next steps
 
-You have successfully packaged your automation content into an Execution Environment using `ansible-builder` and VS Code. This image is now ready for upload to an Automation Hub or deployment via Automation Controller. Please click the **Next** button below to proceed to the next module.
+Please click the **Next** button below to proceed to xref:32-ansible-sign.adoc[Lab 3.2 - Introducing supply chain security with ansible-sign].

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -12,9 +12,9 @@ _Learn how to sign content by using ansible-sign and apply supply-chain security
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** Launching OpenShift Dev Spaces
+* **Prepares you for:** xref:99-conclusion.adoc[Conclusion]
 * **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 10 - 20 minutes
+* **Estimated Time:** 15 minutes
 ****
 
 == Learning objectives
@@ -193,7 +193,15 @@ ade install --editable /home/rhel/myansibleproject/collections/ansible_collectio
 .. AAP will verify the content of the project at every sync
 
 
----
+== Summary
+
+In this lab, you have:
+
+* Created a GPG key for signing Ansible content
+* Defined a `MANIFEST.in` to specify files for signing
+* Signed and verified an Ansible project using `ansible-sign`
+* Learned how signed content integrates with Ansible Automation Platform
+
 == Next steps
 
-You have successfully signed and verified your playbook, this ensured that it can't be tampered with and continue to run unnoticed. Please click the **Next** button below to proceed to the next module.
+Please click the **Next** button below to proceed to xref:99-conclusion.adoc[Conclusion].

--- a/content/modules/ROOT/pages/99-conclusion.adoc
+++ b/content/modules/ROOT/pages/99-conclusion.adoc
@@ -8,15 +8,6 @@
 
 _A summary of the Ansible development tools you've learned and resources for continuing your learning journey._
 
-[.sidebar]
-****
-* **Before you start:**
-** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 
-****
-
 == Congratulations! 🎉
 
 You have successfully completed the **"Intro to creating automation with the new Ansible Development Tools"** workshop!
@@ -34,7 +25,6 @@ After logging in to the Ansible Forum, link:https://forum.ansible.com/t/introduc
 Check the "Next Steps" section below to learn how to get the Ansible development tools installed on your own workstation or laptop!
 ====
 
----
 
 == Review of learned concepts
 
@@ -48,7 +38,6 @@ You have reached the end of the *Introduction to Ansible development tools* work
 * **`ansible-navigator`** for a feature-rich terminal-based user interface to run and test your execution environments.
 * **Ansible Molecule** for testing your collections in isolated, reproducible environments.
 
----
 
 == Call to action: Run `ansible-dev-tools` on your own workstation!
 

--- a/content/modules/ROOT/pages/appendix.adoc
+++ b/content/modules/ROOT/pages/appendix.adoc
@@ -57,3 +57,7 @@
 | `ansible-sign project gpg-verify .`
 | Verify project signatures
 |===
+
+== Contributing to this lab
+
+If you see an error in this lab, fork and submit a pull request against link:https://github.com/rhpds/ansible-dev-tools-showroom[https://github.com/rhpds/ansible-dev-tools-showroom^]


### PR DESCRIPTION
## Summary

- Standardize section ordering: Learning objectives before Lab briefing in all modules
- Standardize closing pattern: Summary → Troubleshooting → Next steps
- Fix task heading levels in 00-introduction (`==` → `===`)
- Add Lab guide wrapper heading and fold non-task sections into briefing
- Fill sidebar metadata (estimated times, correct xrefs, remove from conclusion)
- Standardize terminology to "section" (was mixed challenge/exercise/lab)
- Remove inconsistent horizontal rules
- Move Contributing section to appendix

## Test plan

- [ ] Verify Antora build completes without errors
- [ ] Check all xref links in Next steps resolve correctly
- [ ] Visual review of rendered pages for consistent structure

Closes https://github.com/leogallego/ansible-dev-tools-showroom/issues/2

🤖 Generated with [Claude Code](https://claude.com/claude-code)