### PR TITLE
Rewrite lab instructions for DevSpaces environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ www/
 # Ignore logs and temporary files
 *.log
 *.tmp
+tmp/
+docs-local/
 
 # Ignore environment-specific files
 .env

--- a/content/modules/ROOT/pages/00-introduction.adoc
+++ b/content/modules/ROOT/pages/00-introduction.adoc
@@ -67,35 +67,57 @@ Before we begin, here are some tips to improve your lab experience:
 
 == Task 1: Launch the Dev Spaces workspace
 
-. Launch the link:{openshift_cluster_console_url}[OpenShift Web Console^]
-. Select the **htpasswd_provider** button and use the credentials provided in the xref:environment-details.adoc[Environment Details] page to log in to the OpenShift console
-. Use the 9-block icon in the upper right to launch _Red Hat OpenShift Dev Spaces_ directly from the OpenShift console header
-+
-image::11-platform-dev-spaces/intro-dev_spaces_shortcut.png[OpenShift console header showing the 9-block application launcher icon for quick access to Dev Spaces,link=self,window=blank]
-+
-TIP: Alternatively, the direct URL is link:https://devspaces.{openshift_cluster_ingress_domain}[https://devspaces.{openshift_cluster_ingress_domain}^] also available in xref:environment-details.adoc[Environment Details].
+Red Hat OpenShift Dev Spaces gives you a full VS Code environment running in your browser, with all Ansible development tools pre-installed and configured. Instead of spending time installing tools locally, every participant gets an identical, ready-to-use workspace backed by an enterprise container platform.
 
-. The **Ansible Dev Space** workspace will start automatically. Wait a few minutes for the Dev Spaces instance to initialize.
+. In the lab instructions toolbar at the top of this page, click the **Split** button to open a side-by-side view. The right panel will load the Dev Spaces dashboard.
 +
-NOTE: When it has loaded, a Visual Studio Code interface will appear.
-+
-image::11-platform-dev-spaces/intro4.png[Dev Spaces workspace loading screen showing VS Code interface initialization,link=self,window=blank]
+// PLACEHOLDER: screenshot of the floating toolbar highlighting the Split option
+image::00-introduction/showroom-split-toolbar.png[Showroom floating toolbar with Instructions, Split, and Tabs options — Split is highlighted,link=self,window=blank]
 
-. Click the **Trust Publishers and Install** button to trust the extension publishers that are included within the Dev Spaces workspace
-. Click the **Yes, I trust the Authors** button to trust the workspace authors
-. Wait a few minutes until the additional extension icons appear for Ansible and OpenShift on the left side
+. In the Dev Spaces dashboard on the right, click the **Log in with OpenShift** button.
 +
-image::11-platform-dev-spaces/intro5.png[VS Code interface in Dev Spaces showing Ansible and OpenShift extension icons in the left sidebar,link=self,window=blank]
+// PLACEHOLDER: improve screenshot
+image::00-introduction/devspaces-login-openshift.png[Dev Spaces login page showing the Log in with OpenShift button,link=self,window=blank]
 
-== Task 2: Configure the extensions
-
-. Check the **Extensions** section in VS Code, look for the Ansible extension and click the blue **Reload Window** button to update to the latest version
+. Enter your credentials from the xref:environment-details.adoc[Environment Details] page (`{username}` / `{user_password}`) and click **Sign In**.
 +
-image::vscode-devtools-extension-reload.png[Reload extensions in VS Code,link=self,window=blank, opts="border"]
+// PLACEHOLDER: improve screenshot
+image::00-introduction/devspaces-sso-login.png[SSO sign-in form with username and password fields,link=self,window=blank]
 
-. Click on the **Ansible** extension icon in the left sidebar to verify the Ansible Development Tools extension is available
+. Once logged in, you will see the Dev Spaces dashboard. Paste the following Git repository URL into the **Import from Git** field:
 +
-image::11-platform-dev-spaces/intro6.png[Ansible extension interface in VS Code showing available Ansible development tools,link=self,window=blank]
+// PLACEHOLDER: confirm the final Git URL for participants
+[source,text]
+----
+https://github.com/rhpds/ansible-dev-tools-workspace.git
+----
++
+Then click **Create & Open**.
++
+// PLACEHOLDER: screenshot of the Dev Spaces dashboard with the Git URL field and Create & Open button
+image::00-introduction/devspaces-create-workspace.png[Dev Spaces dashboard showing the Git URL input field and Create & Open button,link=self,window=blank]
+
+. A new browser tab (or window) will open showing a short task list while your workspace provisions. After a few seconds, the VS Code interface will appear.
++
+// PLACEHOLDER: screenshot of VS Code fully loaded in the browser
+image::00-introduction/devspaces-vscode-ready.png[VS Code running in the browser inside Dev Spaces with the workspace loaded,link=self,window=blank]
+
+. Switch back to the **browser tab with these lab instructions** to continue with the next task.
++
+TIP: Keep both tabs open throughout the lab — you will switch between the instructions and your VS Code workspace frequently.
+
+. Click the **Trust Publishers and Install** button to trust the extension publishers that are included within the Dev Spaces workspace.
+. Click the **Yes, I trust the Authors** button to trust the workspace authors.
+. Wait a few moments until the Ansible extension icon appears on the left sidebar.
+
+== Task 2: Explore the Ansible extension
+
+. Click on the **Ansible** extension icon (the "A" logo) in the left activity bar to open the Ansible panel. You will see the **Ansible Development Tools** section with shortcuts and guided wizards to scaffold projects, manage execution environments, and perform other common Ansible development tasks. You will use several of these throughout the lab.
+
+. Click **Getting Started** at the top of the Ansible sidebar to open the Ansible Development Tools welcome page. This page gives you an overview of all the available tools, quick-start links, and walkthroughs.
++
+// PLACEHOLDER: screenshot of the Ansible Development Tools welcome page
+image::00-introduction/ansible-getting-started.png[Ansible Development Tools welcome page showing available tools and walkthroughs,link=self,window=blank]
 
 == Task 3: Verify the development environment
 

--- a/content/modules/ROOT/pages/00-introduction.adoc
+++ b/content/modules/ROOT/pages/00-introduction.adoc
@@ -47,11 +47,12 @@ Dev Spaces provides a VS Code environment configured by a link:https://devfile.i
 
 The lab environment includes:
 
-* Red Hat OpenShift cluster
-* Ansible Automation Platform
-* Red Hat OpenShift Dev Spaces (your development environment)
-* link:https://about.gitea.com[Gitea^] Git server
-* Lab instructions (this guide)
+* **Red Hat OpenShift Dev Spaces** — your browser-based VS Code development environment, powered by Eclipse Che
+* **Ansible Development Tools (adt)** — the bundled CLI suite including `ansible-creator`, `ade`, `ansible-lint`, `molecule`, `pytest-ansible`, `tox-ansible`, `ansible-builder`, `ansible-navigator`, and `ansible-sign`
+* **Ansible VS Code extension** — provides content scaffolding wizards, linting integration, and language support
+* **Podman** — container runtime for building Execution Environments and running Molecule tests
+* **Open VSX Registry** — on-premises registry serving VS Code extensions to Dev Spaces
+* **Lab instructions** — this guide (Showroom)
 
 == Lab tips
 

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -74,17 +74,11 @@ NOTE: You should see the scaffolded collection directory structure including fil
 
 First, let's explore the Ansible extension for VS Code.
 
-.   **Check the installed extensions section in VS Code**, look for the Ansible extension and click the blue **Reload Window** button to update to the latest version if you didn't do it in the previous step.
-+
-image::vscode-devtools-extension-reload.png[Reload extensions in VS Code,link=self,window=blank, opts="border"]
-
-.   After the window reloads, locate and open the **Ansible extension icon on the sidebar of VS Code** and click on it. You will see the Ansible sidebar with 3 sections: (1) *Ansible Development Tools*, (2) *Ansible Lightspeed*, and (3) *Ansible Lightspeed Feedback*.
+.   Open the **Ansible extension icon** on the left sidebar of VS Code. You will see the *Ansible Development Tools* section with shortcuts and guided wizards to scaffold projects, manage execution environments, and perform other common Ansible development tasks.
 +
 image::vscode-devtools-ansible-icon.png[Ansible icon in VS Code sidebar,link=self,window=blank, opts="border"]
-
-.   **Collapse the Lightspeed sections** to simplify the view, as we won't be using Lightspeed features for this lab.
 +
-image::Apr-29-2025_at_13.49.45-image.png[Collapsing the Lightspeed sections,link=self,window=blank, opts="border"]
+TIP: The Ansible extension also supports AI-powered assistance through its *LLM settings*. You can configure this later to connect to Ansible Code Assistant or other language model services.
 
 === Task 2: Create a collection project
 

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -52,23 +52,23 @@ Lets start by running `ansible-creator` in the command line to scaffold a collec
 +
 image::vscode-devtools-terminal.png[VS Code terminal,link=self,window=blank, opts="border"]
 
-. **Scaffold a CLI collection with ansible-creator:** Using `ansible-creator` initialize a collection called `mynamespace.my_cli_collection` in the `/projects/ansible-dev-tools-workspace` directory:
+. **Scaffold a CLI collection with ansible-creator:** Using `ansible-creator` initialize a collection called `mynamespace.creatorcollection`:
 +
 [source,sh,role=execute]
 ----
-ansible-creator init collection mynamespace.my_cli_collection /projects/ansible-dev-tools-workspace
+ansible-creator init collection mynamespace.creatorcollection /projects/ansible-dev-tools-workspace/mynamespace.creatorcollection
 ----
 
 . **Inspect the generated collection structure and files:**
 +
 [source,sh,role=execute]
 ----
-ls -lha /projects/ansible-dev-tools-workspace/mynamespace/my_cli_collection
+ls -lha /projects/ansible-dev-tools-workspace/mynamespace.creatorcollection
 ----
 +
 NOTE: You should see the scaffolded collection directory structure including files like `galaxy.yml`, `README.md`, `LICENSE`, and directories like `plugins/`, `tests/`, and `meta/`.
 
-. **Congrats:** You created a default collection. Move to the next tasks to see how to do this in VS Code and how to customize it.
+. **Congrats:** You created a default collection. This collection was created for demonstration purposes only — in the following tasks you will create the collection used throughout the rest of the lab.
 
 === Task 1: Explore the Ansible extension
 
@@ -105,7 +105,7 @@ mycollection
 +
 [source,sh,role=execute]
 ----
-/projects/ansible-dev-tools-workspace/mynamespace/mycollection
+/projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
 +
 * **Check** the box for `Install collection from source code (editable mode)`
@@ -117,18 +117,18 @@ image::vscode-devtools-collection-create.png[Collection creation form,link=self,
 [source,text]
 ----
 ------- ansible-creator logs ---------
-    Note: collection project created at /projects/ansible-dev-tools-workspace/collections/
-          ansible_collections/mynamespace/mycollection
+    Note: collection project created at /projects/ansible-dev-tools-workspace/
+          mynamespace.mycollection
 
 
 ------- ansible-dev-environment logs -------
-Note: Created virtual environment: /projects/ansible-dev-tools-workspace/mynamespace/mycollection/.venv
+Note: Created virtual environment: /projects/ansible-dev-tools-workspace/mynamespace.mycollection/.venv
 Note: Installed collections include: ansible.utils and mynamespace.mycollection
 Note: All python requirements are installed.
 Note: All required system packages are installed.
 Note: A virtual environment was specified but has not been activated.
 Note: Please activate the virtual environment:
-source /projects/ansible-dev-tools-workspace/mynamespace/mycollection/.venv/bin/activate
+source /projects/ansible-dev-tools-workspace/mynamespace.mycollection/.venv/bin/activate
 ----
 
 === Task 3: Create a playbook project
@@ -183,7 +183,7 @@ image::Apr-29-2025_at_13.57.13-image.png[VS Code Explorer icon,link=self,window=
 +
 [source,sh,role=execute]
 ----
-/projects/ansible-dev-tools-workspace/mynamespace/mycollection/
+/projects/ansible-dev-tools-workspace/mynamespace.mycollection/
 ----
 +
 image::May-12-2025_at_18.45.02-image.png[Opening a folder in VS Code,link=self,window=blank, opts="border"]

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -12,9 +12,9 @@ _A guide to using the Ansible extension for Visual Studio Code to scaffold a new
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:**  
+* **Prepares you for:** Labs 1.2, 1.3, and all subsequent modules
+* **Stage:** Create
+* **Estimated Time:** 10 - 15 minutes
 ****
 
 == Lab briefing

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -52,18 +52,18 @@ Lets start by running `ansible-creator` in the command line to scaffold a collec
 +
 image::vscode-devtools-terminal.png[VS Code terminal,link=self,window=blank, opts="border"]
 
-. **Scaffold a CLI collection with ansible-creator:** Using `ansible-creator` initialize a collection called `mynamespace.my_cli_collection` in the `/home/rhel/myansibleproject/collections/ansible_collections` directory:
+. **Scaffold a CLI collection with ansible-creator:** Using `ansible-creator` initialize a collection called `mynamespace.my_cli_collection` in the `/projects/ansible-dev-tools-workspace` directory:
 +
 [source,sh,role=execute]
 ----
-ansible-creator init collection mynamespace.my_cli_collection /home/rhel/myansibleproject/collections/ansible_collections
+ansible-creator init collection mynamespace.my_cli_collection /projects/ansible-dev-tools-workspace
 ----
 
 . **Inspect the generated collection structure and files:**
 +
 [source,sh,role=execute]
 ----
-ls -lha /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/my_cli_collection
+ls -lha /projects/ansible-dev-tools-workspace/mynamespace/my_cli_collection
 ----
 +
 NOTE: You should see the scaffolded collection directory structure including files like `galaxy.yml`, `README.md`, `LICENSE`, and directories like `plugins/`, `tests/`, and `meta/`.
@@ -105,7 +105,7 @@ mycollection
 +
 [source,sh,role=execute]
 ----
-/home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+/projects/ansible-dev-tools-workspace/mynamespace/mycollection
 ----
 +
 * **Check** the box for `Install collection from source code (editable mode)`
@@ -117,18 +117,18 @@ image::vscode-devtools-collection-create.png[Collection creation form,link=self,
 [source,text]
 ----
 ------- ansible-creator logs ---------
-    Note: collection project created at /home/rhel/myansibleproject/collections/
+    Note: collection project created at /projects/ansible-dev-tools-workspace/collections/
           ansible_collections/mynamespace/mycollection
 
 
 ------- ansible-dev-environment logs -------
-Note: Created virtual environment: /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/.venv
+Note: Created virtual environment: /projects/ansible-dev-tools-workspace/mynamespace/mycollection/.venv
 Note: Installed collections include: ansible.utils and mynamespace.mycollection
 Note: All python requirements are installed.
 Note: All required system packages are installed.
 Note: A virtual environment was specified but has not been activated.
 Note: Please activate the virtual environment:
-source /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/.venv/bin/activate
+source /projects/ansible-dev-tools-workspace/mynamespace/mycollection/.venv/bin/activate
 ----
 
 === Task 3: Create a playbook project
@@ -144,7 +144,7 @@ image::May-12-2025_at_18.31.56-image.png[Creating a Playbook project,link=self,w
 +
 [source,sh,role=execute]
 ----
-/home/rhel/myansibleproject
+/projects/ansible-dev-tools-workspace
 ----
 * **Namespace:** 
 +
@@ -168,7 +168,7 @@ image::vscode-devtools-playbook-create.png[Creating a Playbook project,link=self
 [source,text]
 ----
 --- ansible-creator logs ---
-Note: playbook project created at /home/rhel/myansibleproject
+Note: playbook project created at /projects/ansible-dev-tools-workspace
 ----
 
 === Task 4: Open the mycollection folder
@@ -183,7 +183,7 @@ image::Apr-29-2025_at_13.57.13-image.png[VS Code Explorer icon,link=self,window=
 +
 [source,sh,role=execute]
 ----
-/home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/
+/projects/ansible-dev-tools-workspace/mynamespace/mycollection/
 ----
 +
 image::May-12-2025_at_18.45.02-image.png[Opening a folder in VS Code,link=self,window=blank, opts="border"]

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -144,31 +144,29 @@ image::May-12-2025_at_18.31.56-image.png[Creating a Playbook project,link=self,w
 +
 [source,sh,role=execute]
 ----
-/projects/ansible-dev-tools-workspace
+/projects/ansible-dev-tools-workspace/myplaybook
 ----
-* **Namespace:** 
+* **Namespace:**
 +
 [source,sh,role=execute]
 ----
 mynamespace
 ----
-* **Collection:** 
+* **Collection:**
 +
 [source,sh,role=execute]
 ----
-mysecondcollection
+playbookcollection
 ----
 +
 image::vscode-devtools-playbook-create.png[Creating a Playbook project,link=self,window=blank, opts="border"]
-
-
 
 .   **Create the project** by clicking the **Create** button. After a couple of seconds, you should see a success message in the logs.
 +
 [source,text]
 ----
 --- ansible-creator logs ---
-Note: playbook project created at /projects/ansible-dev-tools-workspace
+Note: playbook project created at /projects/ansible-dev-tools-workspace/myplaybook
 ----
 
 === Task 4: Open the mycollection folder

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -169,9 +169,9 @@ image::vscode-devtools-playbook-create.png[Creating a Playbook project,link=self
 Note: playbook project created at /projects/ansible-dev-tools-workspace/myplaybook
 ----
 
-=== Task 4: Open the mycollection folder
+=== Task 4: Open the collection folder and configure the Python environment
 
-Due to a lab infrastructure and VS Code limitation, you will now manually open the folder where your new collection content was created.
+Now you will open the collection folder in VS Code and configure the Python interpreter to use the virtual environment that was created with the collection.
 
 .   **Open the file Explorer** by clicking the Explorer icon (the icon with two files) in the VS Code left sidebar.
 +
@@ -190,8 +190,15 @@ image::May-12-2025_at_18.45.02-image.png[Opening a folder in VS Code,link=self,w
 +
 image::May-06-2025_at_21.58.21-image.png[Scaffolded collection files in the Explorer view,link=self,window=blank, opts="border"]
 
+.   **Activate the Ansible extension** by clicking on the `galaxy.yml` file in the file explorer. This ensures VS Code recognizes the project as an Ansible collection and activates the Ansible language features.
 
-=== Task 5: Compare the CLI-generated with the VS Code–generated collections
+.   **Copy the virtual environment path.** In the file explorer sidebar, locate the `.venv` folder, **right-click** on it, and select **Copy Path**.
+
+.   **Open the Python interpreter selector** by clicking the Python version indicator in the bottom-right corner of the VS Code status bar.
+
+.   In the dropdown that appears at the top of the screen, select **Enter interpreter path...** and paste the `.venv` path you copied. This configures VS Code to use the collection's virtual environment, which includes all the Ansible development tools and dependencies.
+
+=== Task 5: Compare the CLI-generated with the VS Code-generated collections
 
 . **Same layout**
 . **Same defaults**

--- a/content/modules/ROOT/pages/12-ade.adoc
+++ b/content/modules/ROOT/pages/12-ade.adoc
@@ -57,7 +57,7 @@ First, you will activate the Python virtual environment (`.venv`) that `ansible-
 
 .   **Open the `galaxy.yml` file** by clicking on it in the left sidebar.
 
-.   **Activate the Python virtual environment** by clicking the banner that reads `Python: Select Interpreter` in the bottom status bar of VS Code. From the dropdown menu that appears at the top, select the recommended option: **Python 3.11.11 ('.venv': venv)**.
+.   **Activate the Python virtual environment** by clicking the banner that reads `Python: Select Interpreter` in the bottom status bar of VS Code. From the dropdown menu that appears at the top, select the recommended option: **Python 3.12.12 ('.venv': venv)**.
 +
 image::vscode-devtools-python-env.png[Selecting the Python virtual environment in VS Code,link=self,window=blank, opts="border"]
 
@@ -120,7 +120,7 @@ Let's check the versions of the Ansible development tools installed in your envi
 
 .   **Check the tool versions** by running the following command to see the versions of all installed tools:
 +
-[source,bash]
+[source,bash,role=execute]
 ----
 adt --version
 ----
@@ -134,18 +134,18 @@ The output should look similar to this:
 +
 [source,text]
 ----
-(.venv) [rhel@vscode mycollection]$ adt --version
+$ adt --version
 ansible-builder                          3.1.1
-ansible-core                             2.19.5
-ansible-creator                          25.12.0
-ansible-dev-environment                  25.12.2
-ansible-dev-tools                        26.1.0
-ansible-lint                             26.1.1
-ansible-navigator                        26.1.1
-ansible-sign                             0.1.4
-molecule                                 25.12.0
-pytest-ansible                           25.12.0
-tox-ansible                              26.1.0
+ansible-core                             2.20.5
+ansible-creator                          26.4.2
+ansible-dev-environment                  26.4.0
+ansible-dev-tools                        26.4.5
+ansible-lint                             26.4.0
+ansible-navigator                        26.4.0
+ansible-sign                             0.1.5
+molecule                                 26.4.0
+pytest-ansible                           26.4.0
+tox-ansible                              26.3.0
 ----
 +
 NOTE: Versions might differ, don't worry. The list above is an example.
@@ -161,7 +161,7 @@ Now you will use `ade` to install the dependencies you declared in `galaxy.yml`.
 Notice the `-e .` with a dot at the end of the command. This tells `ade` to perform an *editable* (the `-e`) install, creating a link from the virtual env into your working directory (the `.`).
 ====
 +
-[source,bash]
+[source,bash,role=execute]
 ----
 ade install -e .
 ----

--- a/content/modules/ROOT/pages/12-ade.adoc
+++ b/content/modules/ROOT/pages/12-ade.adoc
@@ -211,6 +211,20 @@ sudo dnf install -y python3-cffi python3-cryptography python3-lxml python3-pycpa
 
 .   **Check the new dependency tree.** Finally, run `ade tree -v` again. The output will now show that `ade` has successfully added the `ansible.netcommon` collection to your environment, along with its Python requirements.
 
+.   **Update `build_ignore` in `galaxy.yml`.** When `ade` manages your collection, it creates directories like `.venv` and `collections` inside the collection root. These are development artifacts that should not be included when building the collection tarball. The `build_ignore` field in `galaxy.yml` tells `ansible-galaxy collection build` to exclude them. Open `galaxy.yml` and update the `build_ignore` section to:
++
+[source,yaml]
+----
+build_ignore:
+  - .gitignore
+  - changelogs/.plugin-cache.yaml
+  - .venv
+  - collections
+  - .tox
+----
++
+This ensures that development tooling directories are excluded from the packaged collection artifact. The `.venv` and `collections` entries prevent `ade`-managed content from bloating the tarball, and `.tox` excludes test runner artifacts from `tox-ansible`. We are adding these entries manually due to a known bug — in a future version, `ade` is expected to handle this automatically.
+
 NOTE: Remember the "Install collection from source code (editable mode)" option you selected during the Collection creation wizard? That option used `ade install -e` to automatically create the virtual environment (`.venv`) that you are using now.
 
 ---

--- a/content/modules/ROOT/pages/12-ade.adoc
+++ b/content/modules/ROOT/pages/12-ade.adoc
@@ -12,9 +12,9 @@ _A guide to exploring what `ansible-creator` and `ade` (Ansible Dev Environment)
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 
+* **Prepares you for:** Lab 1.3 and all subsequent modules
+* **Stage:** Create
+* **Estimated Time:** 10 - 15 minutes
 ****
 
 == Lab briefing

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -78,7 +78,7 @@ Now, you will switch to your playbook project folder and create a new playbook t
 
 .   **Open the playbook project folder.** In the VS Code top menu, select **File** → **Open Folder...**.
 
-.   **Enter the correct path.** In the prompt, **enter** the path `/home/rhel/myansibleproject` and **click** the blue **OK** button.
+.   **Enter the correct path.** In the prompt, **enter** the path `/projects/ansible-dev-tools-workspace` and **click** the blue **OK** button.
 +
 image::vscode-devtools-folder-myansibleproject.png[Open Ansible Playbook Project,link=self,window=blank, opts="border"]
 

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -137,9 +137,40 @@ image::vscode-devtools-lint-fix.png[Ansible Lint settings,link=self,window=blank
 
 === Task 4: Run the playbook
 
-Now that your playbook is lint-free, let's run it using both `ansible-playbook` and `ansible-navigator`. Go back to the **VS Code file Explorer** view.
+Now that your playbook is lint-free, let's run it. Go back to the **VS Code file Explorer** view.
 
-.   **Run with `ansible-playbook`.** In the VS Code file explorer, **right-click** your `mycowsay.yml` playbook. From the context menu, select **Run Ansible Playbook**. The output in the terminal should display a friendly cow saying "Hello, Ansible!".
+.   **Run with `ansible-playbook`.** In the VS Code file explorer, **right-click** your `mycowsay.yml` playbook. From the context menu, select **Run Ansible Playbook**.
++
+The playbook will **fail** with an error similar to:
++
+[source,text]
+----
+No such file or directory: 'cowsay'
+----
++
+This is expected! Your module calls the `cowsay` command, but the Python package that provides it is not installed in your virtual environment yet.
+
+.   **Add the missing Python dependency.** Open the `requirements.txt` file in the collection root. This file declares the Python packages your collection needs. Add `cowsay` to it:
++
+[source,text,role=execute]
+----
+cowsay
+----
++
+Save the file.
++
+NOTE: The `requirements.txt` file is for **Python packages** that can be installed with `pip`. In the previous module you saw how `ade` handles **system packages** (installed with `dnf`). When a dependency is available as a Python package, prefer `requirements.txt` — it works in any environment, including containers where the system filesystem may be read-only.
+
+.   **Re-run `ade install` to pick up the new dependency:**
++
+[source,bash,role=execute]
+----
+ade install -e .
+----
++
+You should see `cowsay` included in the installed packages.
+
+.   **Run the playbook again.** **Right-click** your `mycowsay.yml` playbook and select **Run Ansible Playbook**. This time it should succeed and display a friendly cow saying "Hello, Ansible!".
 +
 image::vscode-devtools-cowsay-run1.png[Playbook output with cowsay message,link=self,window=blank, opts="border"]
 

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -76,7 +76,9 @@ if __name__ == '__main__':
 
 Now, you will switch to your playbook project folder and create a new playbook that calls your custom module.
 
-.   **Create a new playbook file.** In the VS Code file explorer on the left, expand the `myplaybook` folder in the workspace root (next to `mynamespace.mycollection`), **right-click** on `myplaybook` and select **New File**. Name the file `mycowsay.yml`.
+.   **Create a `playbooks` directory.** In the VS Code file explorer on the left, **right-click** on `mynamespace.mycollection` and select **New Folder**. Name it `playbooks`.
+
+.   **Create a new playbook file.** **Right-click** on the newly created `playbooks` folder and select **New File**. Name the file `mycowsay.yml`.
 
 .   **Add the playbook content.** **Copy** and **paste** the following content into the `mycowsay.yml` file:
 +

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -40,7 +40,7 @@ In this exercise, you will copy an existing Python module into your collection's
 
 First, you will create a new Python file and add the code for a simple `cowsay` module.
 
-.   **Create the module file.** In the VS Code file explorer on the left, expand the `plugins` directory, then right-click on the `modules` directory and select **New File**. Name the file `cowsay.py`.
+.   **Create the module file.** In the VS Code file explorer on the left, expand the `mynamespace.mycollection` > `plugins` > `modules` directory path, then right-click on `modules` and select **New File**. Name the file `cowsay.py`.
 
 .   **Add the Python code.** **Copy** the following Python code and **paste** it into the `cowsay.py` file you just created.
 +
@@ -76,13 +76,7 @@ if __name__ == '__main__':
 
 Now, you will switch to your playbook project folder and create a new playbook that calls your custom module.
 
-.   **Open the playbook project folder.** In the VS Code top menu, select **File** → **Open Folder...**.
-
-.   **Enter the correct path.** In the prompt, **enter** the path `/projects/ansible-dev-tools-workspace` and **click** the blue **OK** button.
-+
-image::vscode-devtools-folder-myansibleproject.png[Open Ansible Playbook Project,link=self,window=blank, opts="border"]
-
-.   After the window reloads, **create a new playbook file.** In the file explorer on the left, **right-click** in the empty space below `site.yml` and select **New File**. Name the file `mycowsay.yml`.
+.   **Create a new playbook file.** In the VS Code file explorer on the left, expand the `myplaybook` folder in the workspace root (next to `mynamespace.mycollection`), **right-click** on `myplaybook` and select **New File**. Name the file `mycowsay.yml`.
 
 .   **Add the playbook content.** **Copy** and **paste** the following content into the `mycowsay.yml` file:
 +
@@ -113,7 +107,7 @@ image::vscode-devtools-extension-settings.png[Ansible Extension Settings,link=se
 
 .   **Enable the linter and auto-fix.** In the search bar at the top, type `lint` to filter the settings.
 * Make sure the checkbox for `Ansible › Validation › Lint: Enabled` is checked.
-* In the `Ansible › Validation › Lint: Arguments` field below, enter `--fix`. This tells the linter to automatically fix issues it finds.
+* Check the `Ansible › Validation › Lint: Auto Fix On Save` checkbox. This tells the linter to automatically fix issues when you save a file.
 +
 image::vscode-devtools-lint-fix.png[Ansible Lint settings,link=self,window=blank, opts="border"]
 

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -12,9 +12,9 @@ _A guide to adding a custom module to your Ansible collection and using it in a 
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:**
+* **Prepares you for:** Module 2 (Test) and Module 3 (Deploy)
+* **Stage:** Create
+* **Estimated Time:** 15 - 20 minutes
 ****
 
 == Lab briefing

--- a/content/modules/ROOT/pages/21-molecule.adoc
+++ b/content/modules/ROOT/pages/21-molecule.adoc
@@ -79,8 +79,7 @@ Now, let's explore the test scenario that was automatically added to your collec
 
 When you created the collection in the previous modules, `ansible-creator` also generated a Molecule test scenario named `integration_hello_world`.
 
-.   **Locate the Molecule scenario.** In the VS Code file explorer, **expand** the following directory path: __collections > ansible_collections > mynamespace > mycollection > extensions > molecule
- > integration_hello_world__. 
+.   **Locate the Molecule scenario.** In the VS Code file explorer, **expand** the following directory path: __mynamespace.mycollection > extensions > molecule > integration_hello_world__. 
  
 NOTE: You can also copy and paste the path: `mynamespace.mycollection/extensions/molecule/integration_hello_world`.
 
@@ -116,7 +115,7 @@ This playbook runs during the **converge** stage of the Molecule lifecycle. It's
 
 Before running tests, let's understand what those tests actually verify. This is where assertion-based testing comes into play.
 
-.   **Navigate to the tests directory.** In the VS Code file explorer, **expand** the following path: __collections > ansible_collections > mynamespace > mycollection > tests > integration > targets > hello_world__.
+.   **Navigate to the tests directory.** In the VS Code file explorer, **expand** the following path: __mynamespace.mycollection > tests > integration > targets > hello_world__.
 
 .   **Examine the test tasks.** Within the `hello_world` directory, **open** the `tasks/main.yml` file. This file contains the actual test assertions that Molecule will execute during the verify stage.
 
@@ -160,7 +159,7 @@ image::May-12-2025_at_21.51.02-image.png[Creating a Collection plugin,link=self,
 +
 [source,text,role=execute]
 ----
-/projects/ansible-dev-tools-workspace/mynamespace/mycollection/
+/projects/ansible-dev-tools-workspace/mynamespace.mycollection/
 ----
 +
 * **Plugin type:** `Filter`
@@ -184,7 +183,7 @@ Finally, you will use the command line to run the Molecule test scenario and obs
 +
 [source,bash,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection/extensions/
+cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection/extensions/
 ----
 
 .   **Run a bare Molecule test.** First, run `molecule test` without specifying a scenario. 
@@ -246,7 +245,7 @@ Verify you're in the correct directory by running `pwd`. You should be in:
 +
 [source,bash]
 ----
-/projects/ansible-dev-tools-workspace/mynamespace/mycollection/extensions/
+/projects/ansible-dev-tools-workspace/mynamespace.mycollection/extensions/
 ----
 
 . **If you see "No scenario name provided" errors:**

--- a/content/modules/ROOT/pages/21-molecule.adoc
+++ b/content/modules/ROOT/pages/21-molecule.adoc
@@ -82,7 +82,7 @@ When you created the collection in the previous modules, `ansible-creator` also 
 .   **Locate the Molecule scenario.** In the VS Code file explorer, **expand** the following directory path: __collections > ansible_collections > mynamespace > mycollection > extensions > molecule
  > integration_hello_world__. 
  
-NOTE: You can also copy and paste the path: `collections/ansible_collections/mynamespace/mycollection/extensions/molecule/integration_hello_world`.
+NOTE: You can also copy and paste the path: `mynamespace.mycollection/extensions/molecule/integration_hello_world`.
 
 .   **Examine the Molecule configuration.** Within the `integration_hello_world` directory, **open** the `molecule.yml` file. Molecule uses this file to define the settings and scenarios for testing the Ansible collection.
 +
@@ -160,7 +160,7 @@ image::May-12-2025_at_21.51.02-image.png[Creating a Collection plugin,link=self,
 +
 [source,text,role=execute]
 ----
-/home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/
+/projects/ansible-dev-tools-workspace/mynamespace/mycollection/
 ----
 +
 * **Plugin type:** `Filter`
@@ -184,7 +184,7 @@ Finally, you will use the command line to run the Molecule test scenario and obs
 +
 [source,bash,role=execute]
 ----
-cd /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/extensions/
+cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection/extensions/
 ----
 
 .   **Run a bare Molecule test.** First, run `molecule test` without specifying a scenario. 
@@ -246,7 +246,7 @@ Verify you're in the correct directory by running `pwd`. You should be in:
 +
 [source,bash]
 ----
-/home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/extensions/
+/projects/ansible-dev-tools-workspace/mynamespace/mycollection/extensions/
 ----
 
 . **If you see "No scenario name provided" errors:**

--- a/content/modules/ROOT/pages/21-molecule.adoc
+++ b/content/modules/ROOT/pages/21-molecule.adoc
@@ -11,9 +11,9 @@ _A guide to testing your Ansible collection using Ansible Molecule and a pre-con
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 
+* **Prepares you for:** Labs 2.2 and 2.3
+* **Stage:** Test
+* **Estimated Time:** 10 - 15 minutes
 ****
 
 == Learning objectives

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -103,7 +103,7 @@ MODULES_PATH = os.path.join(PROJECT_ROOT, 'plugins', 'modules')
 os.environ['ANSIBLE_LIBRARY'] = MODULES_PATH
 
 # 2. Set ANSIBLE_COLLECTIONS_PATH so Ansible can resolve the full namespace
-# This points to: .../myansibleproject/collections
+# This points to: .../ansible-dev-tools-workspace
 # We navigate up 3 levels from PROJECT_ROOT:
 #   mycollection -> mynamespace -> ansible_collections -> collections root
 # This allows Ansible to find modules using FQCN (mynamespace.mycollection.cowsay)
@@ -190,7 +190,7 @@ This test validates both the module's execution (no failures, correct change sta
 +
 [source,ini,role=execute]
 ----
-cd /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection
 source .venv/bin/activate
 ----
 

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -103,11 +103,9 @@ MODULES_PATH = os.path.join(PROJECT_ROOT, 'plugins', 'modules')
 os.environ['ANSIBLE_LIBRARY'] = MODULES_PATH
 
 # 2. Set ANSIBLE_COLLECTIONS_PATH so Ansible can resolve the full namespace
-# This points to: .../ansible-dev-tools-workspace
-# We navigate up 3 levels from PROJECT_ROOT:
-#   mycollection -> mynamespace -> ansible_collections -> collections root
-# This allows Ansible to find modules using FQCN (mynamespace.mycollection.cowsay)
-COLLECTIONS_PATH = os.path.abspath(os.path.join(PROJECT_ROOT, '../../..'))
+# The 'collections/' directory is created by 'ade install -e .' inside the
+# collection root and contains symlinks for proper FQCN resolution.
+COLLECTIONS_PATH = os.path.join(PROJECT_ROOT, 'collections')
 os.environ['ANSIBLE_COLLECTIONS_PATH'] = COLLECTIONS_PATH
 
 # Optional: Uncomment to debug path configuration issues

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -190,7 +190,7 @@ This test validates both the module's execution (no failures, correct change sta
 +
 [source,ini,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 source .venv/bin/activate
 ----
 

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -12,9 +12,9 @@ _Learn how to do functional testing for your Ansible content using pytest-ansibl
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:**
+* **Prepares you for:** Lab 2.3
+* **Stage:** Test
+* **Estimated Time:** 10 - 15 minutes
 ****
 
 == Learning objectives

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -186,15 +186,14 @@ This test validates both the module's execution (no failures, correct change sta
 . *Open the VS Code Terminal if you don't have one*
 
 
-. *Verify the VS Code Terminal is in the venv:*
+. *Make sure the VS Code terminal is in the collection directory:*
 +
-[source,ini,role=execute]
+[source,bash,role=execute]
 ----
 cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
-source .venv/bin/activate
 ----
 
-. *From the root of the collection repository (`mycollection/`), run:*
+. *Run the tests:*
 +
 [source,bash,role=execute]
 ----

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -68,123 +68,120 @@ Crucially, look for **`with tox-ansible`**. This confirms the plugin is active.
 cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection/
 ----
 
-=== Task 2: Create a minimal Tox configuration
+=== Task 2: Configure tox-ansible
 
-Because we are using the plugin, we don't need to manually define every single test environment. We just need to tell tox global settings.
+When `ansible-creator` scaffolded your collection, it created a `tox-ansible.ini` file. This is the configuration file for the `tox-ansible` plugin — it is separate from `tox.ini` on purpose, so it does not interfere with standard tox workflows.
 
-.   **Create the `tox.ini` file.**
-    Right-click the collection root folder, select **New File**, name it `tox.ini`, and paste the following:
+The plugin uses `tox-ansible.ini` to control which Python versions and Ansible versions to include or skip in the test matrix. Without it, `tox-ansible` would generate environments for every supported Python and Ansible version combination, resulting in a very large matrix.
+
+.   **Open the `tox-ansible.ini` file** in the collection root and replace its contents with:
 
 +
 [source,ini]
 ----
-[tox]
-# Global tox settings
-envlist = lint, unit
-skip_missing_interpreters = True
-requires =
-    tox-ansible
-
-[testenv]
-# This section configures the default behavior for all environments
-usedevelop = true
-deps =
-    pytest
-    pytest-ansible
-    ansible-lint
-    molecule-plugins[podman]
-
 [ansible]
-# Configuration specific to the tox-ansible plugin
-# This limits the matrix to Ansible 2.15 and 2.16 to save time/resources
-ansible_core_versions =
+skip =
+    py3.7
+    py3.8
+    py3.9
+    py3.10
+    py3.11
+    py3.13
+    py3.14
+    2.9
+    2.10
+    2.11
+    2.12
+    2.13
+    2.14
     2.15
     2.16
+    2.17
+    2.18
+    2.19
+    devel
+    milestone
 ----
 
 .   **Understanding the config:**
-    * `requires = tox-ansible`: Ensures the plugin is present before running.
-    * `ansible_core_versions`: The plugin normally attempts to test against *every* supported Ansible version. We limit this to 2.15 and 2.16 to keep the lab fast.
-    * We do *not* have a `[testenv:lint]` or `[testenv:molecule]` section. The plugin creates these for us!
+    * The `skip` list excludes Python versions and Ansible versions that are not available in our environment. This leaves only `py3.12` and `ansible-core 2.20`, keeping the test matrix small and fast.
+    * You do *not* need a `tox.ini` file — the plugin handles environment creation, dependency installation, and test execution automatically.
+    * You do *not* need to define `[testenv:lint]` or `[testenv:molecule]` sections. The plugin creates these for you!
 
 === Task 3: Explore the auto-generated environments
 
-Now that the config exists, let's see what the plugin found in your project.
+Now that the config is updated, let's see what the plugin found in your project. The `--ansible` flag activates the plugin and `-c tox-ansible.ini` tells tox to use our configuration file.
 
 .   **List all available environments:**
 +
 [source,bash,role=execute]
 ----
-tox list
+tox --ansible -c tox-ansible.ini list
 ----
 +
 **Observe the magic:**
-Even though your `tox.ini` is tiny, you will see a massive list of environments. The plugin found your `tests/unit` folder, your `molecule` scenarios, and your linting needs. You should see entries like:
+Even though your `tox-ansible.ini` only contains a skip list, the plugin scanned your collection and auto-generated test environments. You should see entries like:
 +
-* `lint` (Auto-discovered ansible-lint)
-* `py311-ansible2.16-unit` (Auto-discovered pytest)
-* `py311-ansible2.16-molecule-integration_hello_world` (Auto-discovered molecule)
+* `galaxy` (Build and validate collection artifact)
+* `integration-py3.12-2.20` (Auto-discovered molecule scenarios)
+* `sanity-py3.12-2.20` (Auto-discovered sanity tests)
+* `unit-py3.12-2.20` (Auto-discovered pytest)
 +
-NOTE: The `py311` prefix reflects the Python version installed in your environment. In other environments, you may see a different version (e.g., `py312`, `py313`).
+NOTE: The `py3.12` and `2.20` reflect the Python and Ansible versions available in your environment. The plugin automatically matched them based on what is installed and what we did not skip.
 
 === Task 4: Run the tests
 
-Now we let tox orchestrate the execution.
+Now we let tox orchestrate the execution. Remember to always pass `--ansible -c tox-ansible.ini` so the plugin is activated with the correct config.
 
-.   **Run the Linting environment:**
+.   **Run Sanity Tests:**
 +
 [source,bash,role=execute]
 ----
-tox -e lint
+tox --ansible -c tox-ansible.ini -e sanity-py3.12-2.20
 ----
 +
-Tox creates a virtual environment, installs `ansible-lint`, and runs it against your collection.
+Tox creates a virtual environment, installs the required dependencies, and runs `ansible-test sanity` against your collection.
 
 .   **Run Unit Tests:**
-    The plugin allows you to target specific parts of the matrix. Let's run unit tests against Ansible 2.16.
 +
 [source,bash,role=execute]
 ----
-tox -e py311-ansible2.16-unit
+tox --ansible -c tox-ansible.ini -e unit-py3.12-2.20
 ----
 
 .   **Run Integration Tests (Molecule):**
-    Instead of typing the long `molecule test -s ...` command, we use the tox alias.
-    *Note: The environment name depends on the scenario you created in xref:21-molecule.adoc[Lab 2.1].*
+    Instead of typing the long `molecule test -s ...` command, we use the tox environment.
 +
 [source,bash,role=execute]
 ----
-tox -e py311-ansible2.16-molecule-integration_hello_world
+tox --ansible -c tox-ansible.ini -e integration-py3.12-2.20
 ----
 +
 This automatically:
-    1.  Creates a fresh environment.
-    2.  Installs Ansible Core 2.16.
-    3.  Installs Molecule and Podman plugins.
-    4.  Executes the test scenario.
+    1.  Creates a fresh virtual environment.
+    2.  Installs Ansible Core 2.20.
+    3.  Installs Molecule and its dependencies.
+    4.  Executes the test scenarios.
 
-=== Task 5: Running a group of tests
+=== Task 5: Build and validate the collection
 
-A key feature of tox is running multiple tests with one command.
+The `galaxy` environment builds your collection tarball and runs `galaxy-importer` to validate it.
 
-.   **Run all tests for a specific Ansible version:**
-    You can use "factors" to match multiple environments.
+.   **Run the galaxy environment:**
 +
 [source,bash,role=execute]
 ----
-tox -f ansible2.16
+tox --ansible -c tox-ansible.ini -e galaxy
 ----
-+
-This command tells tox: "Run every test environment that includes 'ansible2.16' in its name." This effectively runs your Unit tests AND Molecule tests for that version in one go.
 
 
 == Troubleshooting
 
-**"InterpreterNotFound"**
-If you see `SKIPPED: InterpreterNotFound: python3.9`, this is normal. We added `skip_missing_interpreters = True` to your config. It simply means the lab environment doesn't have that specific Python version installed.
+**"provided environments not found"**
+Make sure you are passing both `--ansible` and `-c tox-ansible.ini`. Without `--ansible`, the plugin does not activate and the auto-generated environments won't exist.
 
 **"No environments matched"**
-If `tox -l` returns nothing or very few items:
+If `tox --ansible -c tox-ansible.ini list` returns no environments:
 1. Ensure you are in the directory containing `galaxy.yml`.
 2. Ensure you actually created the `tests/unit` folder or `molecule` scenarios in previous modules. The plugin only generates environments for tests that actually exist.
 
@@ -193,9 +190,9 @@ If `tox -l` returns nothing or very few items:
 
 In this lab, you utilized the **tox-ansible** plugin to dramatically simplify test automation.
 
-* **Orchestration:** You replaced manual `ansible-lint`, `pytest`, and `molecule` commands with a unified `tox` interface.
-* **Auto-discovery:** You learned how the plugin scans your project to generate the test matrix automatically.
-* **Matrix Testing:** You validated your code against specific Ansible Core versions (2.15, 2.16) without managing the dependencies manually.
+* **Orchestration:** You replaced manual `pytest`, `molecule`, and `ansible-test` commands with a unified `tox` interface.
+* **Auto-discovery:** You learned how the plugin scans your collection structure and the `tox-ansible.ini` config to generate the test matrix automatically.
+* **Convention over Configuration:** You ran sanity, unit, integration, and galaxy validation tests with a single configuration file and no manual environment definitions.
 
 == Next steps
 

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -65,7 +65,7 @@ Crucially, look for **`with tox-ansible`**. This confirms the plugin is active.
 +
 [source,bash,role=execute]
 ----
-cd /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/
+cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection/
 ----
 
 === Task 2: Create a minimal Tox configuration

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -11,8 +11,8 @@ _A guide to automating your testing workflow using the tox-ansible plugin._
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** Testing your Ansible content with tox-ansible
-* **Lab Type:** Optional
+* **Prepares you for:** Module 3 (Deploy)
+* **Stage:** Test
 * **Estimated Time:** 10 - 20 minutes
 ****
 

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -77,7 +77,7 @@ The plugin uses `tox-ansible.ini` to control which Python versions and Ansible v
 .   **Open the `tox-ansible.ini` file** in the collection root and replace its contents with:
 
 +
-[source,ini]
+[source,ini,role=execute]
 ----
 [ansible]
 skip =

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -65,7 +65,7 @@ Crucially, look for **`with tox-ansible`**. This confirms the plugin is active.
 +
 [source,bash,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection/
+cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection/
 ----
 
 === Task 2: Create a minimal Tox configuration

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -290,7 +290,7 @@ Use `ansible-navigator` to run your `mycowsay.yml` playbook with your newly crea
 +
 [source,bash,role=execute]
 ----
-ansible-navigator run mycowsay.yml --execution-environment-image mycollection-ee --pull-policy never
+ansible-navigator run /projects/ansible-dev-tools-workspace/mynamespace.mycollection/playbooks/mycowsay.yml --execution-environment-image mycollection-ee --pull-policy never
 ----
 
 . *Test the cowsay module documentation:*

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -185,7 +185,7 @@ Ensure your VS Code terminal is operating in the directory containing your newly
 +
 [source,bash,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
 
 . *Run the `ansible-galaxy` command in the VS Code Terminal:*

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -49,7 +49,6 @@ We will define an Execution Environment configuration file by using the Ansible 
 
 === Task 1: Define the Execution Environment definition file
 
-
 The EE configuration is defined in `execution-environment.yml`. To access the features of modern Ansible tooling, we must explicitly declare `version: 3` in the definition file.
 
 . *Create the Execution environment project in VS Code:*
@@ -59,14 +58,14 @@ Open the **Ansible extension** in the VS Code sidebar and click the **Execution 
 image::vscode-devtools-ee-sidebar.png[EE wizard creator in VS Code,link=self,window=blank, opts="border"]
 
 .   **Fill out the Execution environment project details**. Use the following information:
-* **Destination path:** 
+* **Destination path:**
 +
 [source,bash,role=execute]
 ----
-/projects/ansible-dev-tools-workspace
+/projects/ansible-dev-tools-workspace/mycollection-ee
 ----
 +
-* **Base image:** Select the `registry.redhat.io` option from the dropdown to use the Red Hat supported image. 
+* **Base image:** Select the `registry.redhat.io` option from the dropdown to use the Red Hat supported image.
 +
 NOTE: This will require to be logged in to the registry before building the image. For the lab this is not required.
 * **Additional collections:**
@@ -76,14 +75,14 @@ NOTE: This will require to be logged in to the registry before building the imag
 mynamespace.mycollection
 ----
 +
-* **Additional python packages:** 
+* **Additional python packages:**
 +
 [source,bash,role=execute]
 ----
 cowsay
 ----
 +
-* **Tag:** 
+* **Tag:**
 +
 [source,bash,role=execute]
 ----
@@ -94,15 +93,16 @@ mycollection-ee
 * Click the blue **Build** button. You might need to scroll down to find it.
 +
 image::vscode-devtools-ee-create.png[Creating an EE project,link=self,window=blank, opts="border"]
-
++
+TIP: The CLI equivalent of this wizard is: `ansible-creator init execution_env --ee-base-image registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest --ee-collections mynamespace.mycollection --ee-python-deps cowsay --ee-name mycollection-ee /projects/ansible-dev-tools-workspace/mycollection-ee`
 
 . *Open the `execution-environment.yml` file:*
 +
-In the VS Code file explorer view, look for and open the newly created file named `execution-environment.yml`. It should be in the root of the workspace project directory. 
+In the VS Code file explorer, expand the `mycollection-ee` folder and open `execution-environment.yml`.
 
 . *Check the EE blueprint content:*
 +
-This configuration defines the base image, includes the collection dependencies (as an alternative to pull requirements from `requirements.txt` and `requirements.yml`), and explicitly adds the system dependency (`cowsay`) needed for your custom module. The file should look like the one below:
+This configuration defines the base image, includes the collection dependencies, and explicitly adds the Python dependency (`cowsay`) needed for your custom module. The file should look similar to the one below:
 +
 [source,yaml]
 ----
@@ -110,36 +110,32 @@ This configuration defines the base image, includes the collection dependencies 
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:latest
+    name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
+
 dependencies:
-  ansible_core:
-    package_pip: ansible-core
-  ansible_runner:
-    package_pip: ansible-runner
+  python_interpreter:
+    python_path: /usr/bin/python3.12
+
+  python:
+    - cowsay
+
   galaxy:
     collections:
       - name: mynamespace.mycollection
-  python:
-    - cowsay
+
 options:
+  package_manager_path: /usr/bin/microdnf
   tags:
     - mycollection-ee
-  package_manager_path: /usr/bin/microdnf
 ----
 +
-[IMPORTANT]
-.microdnf requirement
-====
-Because the base image (`ee-minimal-rhel8:latest`) is built on Universal Base Image (UBI) minimal, which uses `microdnf`, you must specify `package_manager_path: /usr/bin/microdnf` in the options section for the build to succeed.
-====
-
-. *Let's customize the EE blueprint content:*
+. *Customize the EE blueprint for local development:*
 +
-We will be making two modifications to the created file, as we are building an EE to test our local developed collection, we need to specify to `ansible-builder` we will be working with a local tarball, as our collection is not yet available in Ansible Galaxy or Ansible Automation Platform's (AAP) Automation Hub.
+Since our collection is not yet published to Ansible Galaxy or Automation Hub, we need to tell `ansible-builder` to use a local tarball instead.
 +
-First we will add a section called `additional_build_files`, where we will input the source (`src`) file of the collection and the destination (`dest`) for the build context
+We will make two modifications: first, add an `additional_build_files` section to copy the collection tarball into the build context; second, modify the `galaxy` section to point to the tarball path using `type: file`.
 +
-Second we will modify the `collection:` section to point to the tarball path, instead of just the collection name, and indicate this by using `type: file` so `ansible-galaxy` uses the local file and avoids we copied to the build context in the previous step.
+Replace the contents of `execution-environment.yml` with:
 +
 [source,yaml,role=execute]
 ----
@@ -147,22 +143,21 @@ Second we will modify the `collection:` section to point to the tarball path, in
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:latest
+    name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
 
 dependencies:
-  ansible_core:
-    package_pip: ansible-core
-  ansible_runner:
-    package_pip: ansible-runner
+  python_interpreter:
+    python_path: /usr/bin/python3.12
+
   galaxy:
     collections:
-      # 2. Tell Galaxy to look inside the local folder we created below
+      # Tell Galaxy to look inside the local folder we created below
       - name: collection_tarballs/mynamespace-mycollection-1.0.0.tar.gz
         type: file
   python:
     - cowsay
 
-# 1. Copy the file into a dedicated folder named 'collection_tarballs'
+# Copy the tarball into a dedicated folder named 'collection_tarballs'
 additional_build_files:
   - src: mynamespace-mycollection-1.0.0.tar.gz
     dest: collection_tarballs
@@ -171,44 +166,36 @@ options:
   tags:
     - mycollection-ee
   package_manager_path: /usr/bin/microdnf
-
 ----
 +
-
-. *Save the file:*
+**Understanding the customizations:**
 +
-Save the `execution-environment.yml` file.
+* `python_interpreter.python_path`: The AAP 26 base image ships with Python 3.12 — this tells `ansible-builder` to use it instead of the default Python 3.9.
+* `additional_build_files`: Copies the collection tarball into the build context under `collection_tarballs/`.
+* `type: file` in the `galaxy` section: Tells `ansible-galaxy` to install the collection from the local tarball instead of downloading it from Galaxy.
+* `package_manager_path`: The base image uses `microdnf` as the package manager.
 
-. *Make sure you are in `mycollection` directory:*
+. *Save the file.*
+
+. *Package the collection as a tarball:*
 +
-Ensure your VS Code terminal is operating in the directory containing your newly created execution-environment.yml
+Before building the EE, we need to package the collection. The `build_ignore` entries you added to `galaxy.yml` earlier ensure that development directories (`.venv`, `collections`, `.tox`) are excluded from the package.
 +
 [source,bash,role=execute]
 ----
 cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
+ansible-galaxy collection build --output-path /projects/ansible-dev-tools-workspace/mycollection-ee/
 ----
-
-. *Run the `ansible-galaxy` command in the VS Code Terminal:*
-+
-Before we move on to build our Execution Environment, we need to package our collection into a tarball. The `build_ignore` entries you added to `galaxy.yml` earlier ensure that development directories (`.venv`, `collections`, `.tox`) are excluded from the package.
-+
-[source,bash,role=execute]
-----
-ansible-galaxy collection build --output-path /projects/ansible-dev-tools-workspace/
-----
-
 
 === Task 2: Review the generated Containerfile (dry run)
 
 Before executing the full build, we can use the `ansible-builder create` command to generate the `Containerfile` and build context directory (`context/`). This is helpful for debugging the build steps without spending time on the full image assembly.
 
-. *Make sure you are in the workspace project directory:*
-+
-Ensure your VS Code terminal is operating in the directory containing your newly created execution-environment.yml
+. *Navigate to the EE project directory:*
 +
 [source,bash,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace
+cd /projects/ansible-dev-tools-workspace/mycollection-ee
 ----
 
 . *Run the `ansible-builder create` command in the VS Code Terminal:*
@@ -261,7 +248,7 @@ The build command executes the container build across 4 internal stages: Base, G
 Successfully tagged localhost/mynamespace/mycollection-ee:latest
 6492fc97cd316aba11934f050e9ff5b8edf52972c80934ca70e122f1965bf62c
 
-Complete! The build context can be found at: /projects/ansible-dev-tools-workspace/context
+Complete! The build context can be found at: /projects/ansible-dev-tools-workspace/mycollection-ee/context
 ----
 
 . *Verify the container image exists:*

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -63,7 +63,7 @@ image::vscode-devtools-ee-sidebar.png[EE wizard creator in VS Code,link=self,win
 +
 [source,bash,role=execute]
 ----
-/home/rhel/myansibleproject
+/projects/ansible-dev-tools-workspace
 ----
 +
 * **Base image:** Select the `registry.redhat.io` option from the dropdown to use the Red Hat supported image. 
@@ -98,7 +98,7 @@ image::vscode-devtools-ee-create.png[Creating an EE project,link=self,window=bla
 
 . *Open the `execution-environment.yml` file:*
 +
-In the VS Code file explorer view, look for and open the newly created file named `execution-environment.yml`. It should be in the root of the `myansibleproject`. 
+In the VS Code file explorer view, look for and open the newly created file named `execution-environment.yml`. It should be in the root of the workspace project directory. 
 
 . *Check the EE blueprint content:*
 +
@@ -185,7 +185,7 @@ Ensure your VS Code terminal is operating in the directory containing your newly
 +
 [source,bash,role=execute]
 ----
-cd /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+cd /projects/ansible-dev-tools-workspace/mynamespace/mycollection
 ----
 
 . *Run the `ansible-galaxy` command in the VS Code Terminal:*
@@ -201,7 +201,7 @@ Run the following commands in the active terminal to generate the collection tar
 +
 [source,bash,role=execute]
 ----
-ansible-galaxy collection build --output-path /home/rhel/myansibleproject/
+ansible-galaxy collection build --output-path /projects/ansible-dev-tools-workspace/
 ----
 Let's re-enable `ade` editable mode now:
 +
@@ -215,13 +215,13 @@ ade install -e .
 
 Before executing the full build, we can use the `ansible-builder create` command to generate the `Containerfile` and build context directory (`context/`). This is helpful for debugging the build steps without spending time on the full image assembly.
 
-. *Make sure you are in the myansibleproject directory:*
+. *Make sure you are in the workspace project directory:*
 +
 Ensure your VS Code terminal is operating in the directory containing your newly created execution-environment.yml
 +
 [source,bash,role=execute]
 ----
-cd /home/rhel/myansibleproject
+cd /projects/ansible-dev-tools-workspace
 ----
 
 . *Run the `ansible-builder create` command in the VS Code Terminal:*
@@ -274,7 +274,7 @@ The build command executes the container build across 4 internal stages: Base, G
 Successfully tagged localhost/mynamespace/mycollection-ee:latest
 6492fc97cd316aba11934f050e9ff5b8edf52972c80934ca70e122f1965bf62c
 
-Complete! The build context can be found at: /home/rhel/myansibleproject/context
+Complete! The build context can be found at: /projects/ansible-dev-tools-workspace/context
 ----
 
 . *Verify the container image exists:*

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -47,6 +47,19 @@ Although new features in the roadmap are coming to simplify the EE building expe
 
 We will define an Execution Environment configuration file by using the Ansible extension wizard in VS Code, then use  `ansible-galaxy` to package our collection, `ansible-builder create` to inspect the generated `Containerfile`, and finally `ansible-builder build` for building the custom EE image, and finish by testing it using Podman (the default container runtime).
 
+=== Task 0: Promote your playbook to the playbook project
+
+Now that your playbook and collection are working, it's time to prepare them for production. In a real workflow, the collection and the playbook project are distributed separately — the collection is packaged into an Execution Environment, while the playbook project is pushed to a Git repository and pulled by Ansible Automation Platform's Controller.
+
+Copy your working playbook from the collection into the `myplaybook` project directory you created in Lab 1.1. In VS Code, expand `mynamespace.mycollection` > `playbooks`, **right-click** on `mycowsay.yml` and select **Copy**. Then expand the `myplaybook` folder in the workspace root, **right-click** on it and select **Paste**.
+
+Alternatively, you can use the terminal:
+
+[source,bash,role=execute]
+----
+cp /projects/ansible-dev-tools-workspace/mynamespace.mycollection/playbooks/mycowsay.yml /projects/ansible-dev-tools-workspace/myplaybook/
+----
+
 === Task 1: Define the Execution Environment definition file
 
 The EE configuration is defined in `execution-environment.yml`. To access the features of modern Ansible tooling, we must explicitly declare `version: 3` in the definition file.
@@ -290,7 +303,7 @@ Use `ansible-navigator` to run your `mycowsay.yml` playbook with your newly crea
 +
 [source,bash,role=execute]
 ----
-ansible-navigator run /projects/ansible-dev-tools-workspace/mynamespace.mycollection/playbooks/mycowsay.yml --execution-environment-image mycollection-ee --pull-policy never
+ansible-navigator run /projects/ansible-dev-tools-workspace/myplaybook/mycowsay.yml --execution-environment-image mycollection-ee --pull-policy never
 ----
 
 . *Test the cowsay module documentation:*

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -11,9 +11,9 @@ _A guide to automating the creation and customization of containerized execution
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** Launching OpenShift Dev Spaces
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 10 - 20 minutes
+* **Prepares you for:** Lab 3.2
+* **Stage:** Deploy
+* **Estimated Time:** 15 - 25 minutes
 ****
 
 == Learning objectives

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -190,24 +190,11 @@ cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 
 . *Run the `ansible-galaxy` command in the VS Code Terminal:*
 +
-Before we move on to build our Execution Environment, we need to package our collection and clean it of unneeded development files. We will be using `ansible-galaxy` and `ade` for this. 
-Before we package the collection in a tarball we will disable the `ade` editable environment (note the dot at the end for the path).
-+
-[source,bash,role=execute]
-----
-ade install .
-----
-Run the following commands in the active terminal to generate the collection tarball. 
+Before we move on to build our Execution Environment, we need to package our collection into a tarball. The `build_ignore` entries you added to `galaxy.yml` earlier ensure that development directories (`.venv`, `collections`, `.tox`) are excluded from the package.
 +
 [source,bash,role=execute]
 ----
 ansible-galaxy collection build --output-path /projects/ansible-dev-tools-workspace/
-----
-Let's re-enable `ade` editable mode now:
-+
-[source,bash,role=execute]
-----
-ade install -e .
 ----
 
 

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -95,34 +95,31 @@ gpg --list-secret-keys
 
 === Task 2: Set up the environment
 
-This task demonstrates how to cryptographically sign an Ansible Project using `ansible-sign`. We will be using the collection directory and our `mycowsay.yml` playbook.
+This task demonstrates how to cryptographically sign an Ansible Project using `ansible-sign`. We will be using the `myplaybook` project directory — the playbook project you created earlier and where you copied your `mycowsay.yml` playbook in the previous module.
 
-. *Make sure you are in the collection directory:*
+. *Make sure you are in the playbook project directory:*
 +
 [source,bash,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
+cd /projects/ansible-dev-tools-workspace/myplaybook
 ----
 
 === Task 3: Create a MANIFEST.in file
 
-. *In VS Code, create a new file called `MANIFEST.in`* in the root of your project. Add the following content to it. We will be excluding a couple of directories and signing a README and playbook. This is only meant as an example, your needs might vary:
+. *In VS Code, create a new file called `MANIFEST.in`* in the `myplaybook` directory. This file controls which files are included in the checksum manifest that `ansible-sign` creates and verifies.
++
+For this lab, we will sign just two files to keep the output simple. In a production environment, you would include all project files to ensure full supply chain integrity.
 +
 [source,bash,role=execute]
 ----
-# Exclude .venv FIRST before any includes
-global-exclude .venv
-global-exclude .venv/*
-prune .venv
-
-# Exclude .git
+# Exclude development artifacts
 global-exclude .git
 global-exclude .git/*
 prune .git
 
-# Now include what you want to sign
+# Include files to sign
 include README.md
-include playbooks/mycowsay.yml
+include mycowsay.yml
 ----
 
 NOTE: Internally, ansible-sign makes use of the distlib.manifest module of Python’s distlib library, and thus MANIFEST.in must follow the syntax that this library specifies. Check the Python Packaging User Guide for an explanation of the MANIFEST.in file directives.

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -104,14 +104,6 @@ This task demonstrates how to cryptographically sign an Ansible Project using `a
 cd /projects/ansible-dev-tools-workspace
 ----
 
-. *Switch `ade` to standard mode:* Before we can sign our packages, we need to disable editable mode to remove the recursive symlinks. 
-+
-[source,bash,role=execute]
-----
-ade install /projects/ansible-dev-tools-workspace/mynamespace.mycollection
-----
-
-
 === Task 3: Create a MANIFEST.in file
 
 . *In VS Code, create a new file called `MANIFEST.in`* in the root of your project. Add the following content to it. We will be excluding a couple of directories and signing a README and playbook. This is only meant as an example, your needs might vary:
@@ -175,13 +167,6 @@ ansible-sign project gpg-verify .
 [OK   ] GPG signature verification succeeded.
 [NOTE ] Checksum manifest: ./.ansible-sign/sha256sum.txt
 [NOTE ] GPG summary: valid signature
-----
-
-. *Switch `ade` back to editable mode:*
-+
-[source,bash,role=execute]
-----
-ade install --editable /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
 
 === Task 6: Enable verification in AAP executions

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -108,7 +108,7 @@ cd /projects/ansible-dev-tools-workspace
 +
 [source,bash,role=execute]
 ----
-ade install /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+ade install /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
 
 
@@ -181,7 +181,7 @@ ansible-sign project gpg-verify .
 +
 [source,bash,role=execute]
 ----
-ade install --editable /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+ade install --editable /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
 
 === Task 6: Enable verification in AAP executions

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -95,13 +95,13 @@ gpg --list-secret-keys
 
 === Task 2: Set up the environment
 
-This task demonstrates how to cryptographically sign an Ansible Project using `ansible-sign`. We will be using the workspace project directory and our `mycowsay.yml` playbook.
+This task demonstrates how to cryptographically sign an Ansible Project using `ansible-sign`. We will be using the collection directory and our `mycowsay.yml` playbook.
 
-. *Make sure you are in the workspace project directory:*
+. *Make sure you are in the collection directory:*
 +
 [source,bash,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace
+cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
 
 === Task 3: Create a MANIFEST.in file
@@ -122,7 +122,7 @@ prune .git
 
 # Now include what you want to sign
 include README.md
-include mycowsay.yml
+include playbooks/mycowsay.yml
 ----
 
 NOTE: Internally, ansible-sign makes use of the distlib.manifest module of Python’s distlib library, and thus MANIFEST.in must follow the syntax that this library specifies. Check the Python Packaging User Guide for an explanation of the MANIFEST.in file directives.

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -95,20 +95,20 @@ gpg --list-secret-keys
 
 === Task 2: Set up the environment
 
-This task demonstrates how to cryptographically sign an Ansible Project using `ansible-sign`. We will be using `myansibleproject` and our `mycowsay.yml` playbook.
+This task demonstrates how to cryptographically sign an Ansible Project using `ansible-sign`. We will be using the workspace project directory and our `mycowsay.yml` playbook.
 
-. *Make sure you are in the `myansibleproject` directory:*
+. *Make sure you are in the workspace project directory:*
 +
 [source,bash,role=execute]
 ----
-cd /home/rhel/myansibleproject
+cd /projects/ansible-dev-tools-workspace
 ----
 
 . *Switch `ade` to standard mode:* Before we can sign our packages, we need to disable editable mode to remove the recursive symlinks. 
 +
 [source,bash,role=execute]
 ----
-ade install /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+ade install /projects/ansible-dev-tools-workspace/mynamespace/mycollection
 ----
 
 
@@ -181,7 +181,7 @@ ansible-sign project gpg-verify .
 +
 [source,bash,role=execute]
 ----
-ade install --editable /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+ade install --editable /projects/ansible-dev-tools-workspace/mynamespace/mycollection
 ----
 
 === Task 6: Enable verification in AAP executions

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -12,9 +12,9 @@ _Learn how to sign content by using ansible-sign and apply supply-chain security
 ****
 * **Before you start:**
 ** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** Launching OpenShift Dev Spaces
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 10 - 20 minutes
+* **Prepares you for:** Conclusion
+* **Stage:** Deploy
+* **Estimated Time:** 10 - 15 minutes
 ****
 
 == Learning objectives

--- a/content/modules/ROOT/pages/99-conclusion.adoc
+++ b/content/modules/ROOT/pages/99-conclusion.adoc
@@ -10,11 +10,7 @@ _A summary of the Ansible development tools you've learned and resources for con
 
 [.sidebar]
 ****
-* **Before you start:**
-** Access to OpenShift Dev Spaces in xref:environment-details.adoc[Environment Details]
-* **Prepares you for:** 
-* **Lab Type:** Foundational (_activities in this lab prepare you for the remaining labs_)
-* **Estimated Time:** 
+* **Estimated Time:** 5 minutes
 ****
 
 == Congratulations! 🎉

--- a/content/modules/ROOT/pages/environment-details.adoc
+++ b/content/modules/ROOT/pages/environment-details.adoc
@@ -4,10 +4,10 @@
 
 Your instructor will provide the following details for your lab environment:
 
-* **OpenShift Console URL:** `{openshift_cluster_console_url}`
 * **Dev Spaces URL:** `https://devspaces.{openshift_cluster_ingress_domain}`
-* **Username:** Provided by instructor
-* **Password:** Provided by instructor
+// PLACEHOLDER: confirm RHDP variable names are wired up in the catalog item
+* **Username:** `{username}`
+* **Password:** `{user_password}`
 
 == Lab environment components
 

--- a/solvers/11-vscode-collection.yml
+++ b/solvers/11-vscode-collection.yml
@@ -41,8 +41,8 @@
 
     # =========================================================================
     # Task 1: Explore the Ansible extension
-    # SKIPPED - Requires VS Code UI interaction (view extension sidebar,
-    # collapse Lightspeed sections). No CLI equivalent.
+    # SKIPPED - Requires VS Code UI interaction (view extension sidebar).
+    # No CLI equivalent.
     # =========================================================================
 
     # =========================================================================

--- a/solvers/11-vscode-collection.yml
+++ b/solvers/11-vscode-collection.yml
@@ -19,8 +19,8 @@
   become: false
 
   vars:
-    base_project_dir: /home/rhel/myansibleproject
-    collections_dir: "{{ base_project_dir }}/collections/ansible_collections"
+    base_project_dir: /projects/ansible-dev-tools-workspace
+    collections_dir: "{{ base_project_dir }}"
 
   tasks:
     # =========================================================================

--- a/solvers/11-vscode-collection.yml
+++ b/solvers/11-vscode-collection.yml
@@ -32,12 +32,12 @@
         state: directory
         mode: "0755"
 
-    - name: "Task 0: Scaffold CLI collection mynamespace.my_cli_collection"
+    - name: "Task 0: Scaffold CLI collection mynamespace.creatorcollection"
       ansible.builtin.command:
         cmd: >-
-          ansible-creator init collection mynamespace.my_cli_collection
-          {{ collections_dir }}
-        creates: "{{ collections_dir }}/mynamespace/my_cli_collection/galaxy.yml"
+          ansible-creator init collection mynamespace.creatorcollection
+          {{ collections_dir }}/mynamespace.creatorcollection
+        creates: "{{ collections_dir }}/mynamespace.creatorcollection/galaxy.yml"
 
     # =========================================================================
     # Task 1: Explore the Ansible extension
@@ -54,13 +54,13 @@
       ansible.builtin.command:
         cmd: >-
           ansible-creator init collection mynamespace.mycollection
-          {{ collections_dir }}/mynamespace/mycollection
-        creates: "{{ collections_dir }}/mynamespace/mycollection/galaxy.yml"
+          {{ collections_dir }}/mynamespace.mycollection
+        creates: "{{ collections_dir }}/mynamespace.mycollection/galaxy.yml"
 
     - name: "Task 2: Install collection in editable mode with ade"
       ansible.builtin.command:
         cmd: ade install -e .
-        chdir: "{{ collections_dir }}/mynamespace/mycollection"
+        chdir: "{{ collections_dir }}/mynamespace.mycollection"
       changed_when: true
 
     # =========================================================================

--- a/solvers/11-vscode-collection.yml
+++ b/solvers/11-vscode-collection.yml
@@ -68,14 +68,14 @@
     # The VS Code wizard creates a playbook project. The CLI equivalent
     # uses ansible-creator init playbook.
     # =========================================================================
-    - name: "Task 3: Scaffold playbook project with mysecondcollection"
+    - name: "Task 3: Scaffold playbook project with playbookcollection"
       ansible.builtin.command:
         cmd: >-
           ansible-creator init playbook
-          {{ base_project_dir }}
+          {{ base_project_dir }}/myplaybook
           --scm-org mynamespace
-          --scm-project mysecondcollection
-        creates: "{{ base_project_dir }}/site.yml"
+          --scm-project playbookcollection
+        creates: "{{ base_project_dir }}/myplaybook/site.yml"
 
     # =========================================================================
     # Task 4: Open the mycollection folder

--- a/solvers/11-vscode-collection.yml
+++ b/solvers/11-vscode-collection.yml
@@ -72,9 +72,8 @@
       ansible.builtin.command:
         cmd: >-
           ansible-creator init playbook
+          mynamespace.playbookcollection
           {{ base_project_dir }}/myplaybook
-          --scm-org mynamespace
-          --scm-project playbookcollection
         creates: "{{ base_project_dir }}/myplaybook/site.yml"
 
     # =========================================================================

--- a/solvers/12-ade.yml
+++ b/solvers/12-ade.yml
@@ -18,7 +18,7 @@
 
   vars:
     collection_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 
   tasks:
     # =========================================================================

--- a/solvers/12-ade.yml
+++ b/solvers/12-ade.yml
@@ -64,6 +64,13 @@
             "ansible.utils": "*"
             "ansible.posix": "*"
 
+          build_ignore:
+            - .gitignore
+            - changelogs/.plugin-cache.yaml
+            - .venv
+            - collections
+            - .tox
+
           repository: ""
           documentation: ""
           homepage: ""
@@ -116,6 +123,13 @@
             "ansible.utils": "*"
             "ansible.posix": "*"
             "ansible.netcommon": "*"
+
+          build_ignore:
+            - .gitignore
+            - changelogs/.plugin-cache.yaml
+            - .venv
+            - collections
+            - .tox
 
           repository: ""
           documentation: ""

--- a/solvers/12-ade.yml
+++ b/solvers/12-ade.yml
@@ -18,7 +18,7 @@
 
   vars:
     collection_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
 
   tasks:
     # =========================================================================

--- a/solvers/13-module.yml
+++ b/solvers/13-module.yml
@@ -63,9 +63,41 @@
         backup: true
 
     # =========================================================================
-    # Task 2: Create a playbook to use the new module
+    # Task 2: Create a playbook to use the new module (pre-lint form)
     # =========================================================================
-    - name: "Task 2: Create mycowsay.yml playbook (already lint-fixed)"
+    - name: "Task 2: Create mycowsay.yml playbook (pre-lint version)"
+      ansible.builtin.copy:
+        dest: "{{ project_dir }}/mycowsay.yml"
+        content: |
+          ---
+          - hosts: localhost
+            tasks:
+              - name: test the cowsay module
+                mynamespace.mycollection.cowsay:
+                  message: Hello, Ansible!
+                register: result
+
+              - name: Display the result
+                ansible.builtin.debug:
+                  msg: "{{ '{{' }} result.message {{ '}}' }}"
+        mode: "0644"
+        backup: true
+
+    # =========================================================================
+    # Task 3: Use ansible-lint to fix the playbook
+    # =========================================================================
+    - name: "Task 3: Run ansible-lint --fix on the playbook"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ansible-lint
+          --fix --nocolor
+          {{ project_dir }}/mycowsay.yml
+        chdir: "{{ collection_dir }}"
+      changed_when: true
+      failed_when: false
+      register: r_lint_fix
+
+    - name: "Task 3: Apply final manual fix (add play name)"
       ansible.builtin.copy:
         dest: "{{ project_dir }}/mycowsay.yml"
         content: |
@@ -81,16 +113,18 @@
               - name: Display the result
                 ansible.builtin.debug:
                   msg: "{{ '{{' }} result.message {{ '}}' }}"
+                  verbosity: 0
         mode: "0644"
         backup: true
 
-    # =========================================================================
-    # Task 3: Use ansible-lint to fix the playbook
-    # SKIPPED - The playbook created above is already in its final lint-fixed
-    # form (includes play name, proper formatting). The VS Code lint settings
-    # configuration (enabling linter, adding --fix argument) is a UI action
-    # that doesn't require a solver.
-    # =========================================================================
+    - name: "Task 3: Verify playbook passes lint"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/ansible-lint
+          --nocolor
+          {{ project_dir }}/mycowsay.yml
+        chdir: "{{ collection_dir }}"
+      changed_when: false
 
     # =========================================================================
     # Task 4: Run the playbook

--- a/solvers/13-module.yml
+++ b/solvers/13-module.yml
@@ -65,6 +65,12 @@
     # =========================================================================
     # Task 2: Create a playbook to use the new module (pre-lint form)
     # =========================================================================
+    - name: "Task 2: Ensure playbooks directory exists"
+      ansible.builtin.file:
+        path: "{{ collection_dir }}/playbooks"
+        state: directory
+        mode: "0755"
+
     - name: "Task 2: Create mycowsay.yml playbook (pre-lint version)"
       ansible.builtin.copy:
         dest: "{{ collection_dir }}/playbooks/mycowsay.yml"

--- a/solvers/13-module.yml
+++ b/solvers/13-module.yml
@@ -67,7 +67,7 @@
     # =========================================================================
     - name: "Task 2: Create mycowsay.yml playbook (pre-lint version)"
       ansible.builtin.copy:
-        dest: "{{ project_dir }}/mycowsay.yml"
+        dest: "{{ collection_dir }}/playbooks/mycowsay.yml"
         content: |
           ---
           - hosts: localhost
@@ -91,7 +91,7 @@
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-lint
           --fix --nocolor
-          {{ project_dir }}/mycowsay.yml
+          {{ collection_dir }}/playbooks/mycowsay.yml
         chdir: "{{ collection_dir }}"
       changed_when: true
       failed_when: false
@@ -99,7 +99,7 @@
 
     - name: "Task 3: Apply final manual fix (add play name)"
       ansible.builtin.copy:
-        dest: "{{ project_dir }}/mycowsay.yml"
+        dest: "{{ collection_dir }}/playbooks/mycowsay.yml"
         content: |
           ---
           - name: Using our cowsay module
@@ -122,7 +122,7 @@
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-lint
           --nocolor
-          {{ project_dir }}/mycowsay.yml
+          {{ collection_dir }}/playbooks/mycowsay.yml
         chdir: "{{ collection_dir }}"
       changed_when: false
 
@@ -135,7 +135,7 @@
       ansible.builtin.command:
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-playbook
-          {{ project_dir }}/mycowsay.yml
+          {{ collection_dir }}/playbooks/mycowsay.yml
       changed_when: false
       environment:
         ANSIBLE_COLLECTIONS_PATH: "{{ project_dir }}/collections"

--- a/solvers/13-module.yml
+++ b/solvers/13-module.yml
@@ -128,14 +128,25 @@
 
     # =========================================================================
     # Task 4: Run the playbook
-    # The VS Code UI right-click "Run Ansible Playbook" and "Run with
-    # Ansible Navigator" are UI actions. We run equivalent CLI commands.
+    # First run fails (cowsay not installed), then add to requirements.txt
+    # and re-run ade install, then run again successfully.
     # =========================================================================
+    - name: "Task 4: Add cowsay to requirements.txt"
+      ansible.builtin.lineinfile:
+        path: "{{ collection_dir }}/requirements.txt"
+        line: "cowsay"
+        create: true
+        mode: "0644"
+
+    - name: "Task 4: Re-run ade install to pick up cowsay dependency"
+      ansible.builtin.command:
+        cmd: "{{ collection_dir }}/.venv/bin/ade install -e ."
+        chdir: "{{ collection_dir }}"
+      changed_when: true
+
     - name: "Task 4: Run playbook with ansible-playbook"
       ansible.builtin.command:
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-playbook
           {{ collection_dir }}/playbooks/mycowsay.yml
       changed_when: false
-      environment:
-        ANSIBLE_COLLECTIONS_PATH: "{{ project_dir }}/collections"

--- a/solvers/13-module.yml
+++ b/solvers/13-module.yml
@@ -18,8 +18,8 @@
 
   vars:
     collection_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
-    project_dir: /home/rhel/myansibleproject
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+    project_dir: /projects/ansible-dev-tools-workspace
 
   tasks:
     # =========================================================================

--- a/solvers/13-module.yml
+++ b/solvers/13-module.yml
@@ -18,7 +18,7 @@
 
   vars:
     collection_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection
     project_dir: /projects/ansible-dev-tools-workspace
 
   tasks:

--- a/solvers/21-molecule.yml
+++ b/solvers/21-molecule.yml
@@ -18,9 +18,9 @@
 
   vars:
     collection_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
     extensions_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/extensions
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection/extensions
 
   tasks:
     # =========================================================================
@@ -61,4 +61,4 @@
       changed_when: true
       environment:
         ANSIBLE_COLLECTIONS_PATH: >-
-          /home/rhel/myansibleproject/collections
+          /projects/ansible-dev-tools-workspace/collections

--- a/solvers/21-molecule.yml
+++ b/solvers/21-molecule.yml
@@ -59,6 +59,3 @@
           -s integration_hello_world
         chdir: "{{ extensions_dir }}"
       changed_when: true
-      environment:
-        ANSIBLE_COLLECTIONS_PATH: >-
-          /projects/ansible-dev-tools-workspace/collections

--- a/solvers/21-molecule.yml
+++ b/solvers/21-molecule.yml
@@ -18,9 +18,9 @@
 
   vars:
     collection_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection
     extensions_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection/extensions
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection/extensions
 
   tasks:
     # =========================================================================

--- a/solvers/21-molecule.yml
+++ b/solvers/21-molecule.yml
@@ -46,7 +46,7 @@
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-creator
           add plugin filter hello_world
-          --path {{ collection_dir }}
+          {{ collection_dir }}
         creates: "{{ collection_dir }}/plugins/filter/hello_world.py"
 
     # =========================================================================

--- a/solvers/22-pytest-ansible.yml
+++ b/solvers/22-pytest-ansible.yml
@@ -19,9 +19,9 @@
 
   vars:
     collection_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection
     tests_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection/tests
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection/tests
 
   tasks:
     # =========================================================================

--- a/solvers/22-pytest-ansible.yml
+++ b/solvers/22-pytest-ansible.yml
@@ -69,11 +69,9 @@
           os.environ['ANSIBLE_LIBRARY'] = MODULES_PATH
 
           # 2. Set ANSIBLE_COLLECTIONS_PATH so Ansible can resolve the full namespace
-          # This points to: .../ansible-dev-tools-workspace
-          # We navigate up 3 levels from PROJECT_ROOT:
-          #   mycollection -> mynamespace -> ansible_collections -> collections root
-          # This allows Ansible to find modules using FQCN (mynamespace.mycollection.cowsay)
-          COLLECTIONS_PATH = os.path.abspath(os.path.join(PROJECT_ROOT, '../../..'))
+          # The 'collections/' directory is created by 'ade install -e .' inside the
+          # collection root and contains symlinks for proper FQCN resolution.
+          COLLECTIONS_PATH = os.path.join(PROJECT_ROOT, 'collections')
           os.environ['ANSIBLE_COLLECTIONS_PATH'] = COLLECTIONS_PATH
         mode: "0644"
         backup: true
@@ -138,8 +136,6 @@
         cmd: "{{ collection_dir }}/.venv/bin/pytest"
         chdir: "{{ collection_dir }}"
       changed_when: false
-      environment:
-        ANSIBLE_COLLECTIONS_PATH: /projects/ansible-dev-tools-workspace/collections
 
     # =========================================================================
     # Task 5: Verify the test results
@@ -149,5 +145,3 @@
         cmd: "{{ collection_dir }}/.venv/bin/pytest -v -s"
         chdir: "{{ collection_dir }}"
       changed_when: false
-      environment:
-        ANSIBLE_COLLECTIONS_PATH: /projects/ansible-dev-tools-workspace/collections

--- a/solvers/22-pytest-ansible.yml
+++ b/solvers/22-pytest-ansible.yml
@@ -19,9 +19,9 @@
 
   vars:
     collection_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
     tests_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection/tests
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection/tests
 
   tasks:
     # =========================================================================
@@ -69,7 +69,7 @@
           os.environ['ANSIBLE_LIBRARY'] = MODULES_PATH
 
           # 2. Set ANSIBLE_COLLECTIONS_PATH so Ansible can resolve the full namespace
-          # This points to: .../myansibleproject/collections
+          # This points to: .../ansible-dev-tools-workspace
           # We navigate up 3 levels from PROJECT_ROOT:
           #   mycollection -> mynamespace -> ansible_collections -> collections root
           # This allows Ansible to find modules using FQCN (mynamespace.mycollection.cowsay)
@@ -139,7 +139,7 @@
         chdir: "{{ collection_dir }}"
       changed_when: false
       environment:
-        ANSIBLE_COLLECTIONS_PATH: /home/rhel/myansibleproject/collections
+        ANSIBLE_COLLECTIONS_PATH: /projects/ansible-dev-tools-workspace/collections
 
     # =========================================================================
     # Task 5: Verify the test results
@@ -150,4 +150,4 @@
         chdir: "{{ collection_dir }}"
       changed_when: false
       environment:
-        ANSIBLE_COLLECTIONS_PATH: /home/rhel/myansibleproject/collections
+        ANSIBLE_COLLECTIONS_PATH: /projects/ansible-dev-tools-workspace/collections

--- a/solvers/23-tox-ansible.yml
+++ b/solvers/23-tox-ansible.yml
@@ -19,7 +19,7 @@
 
   vars:
     collection_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
 
   tasks:
     # =========================================================================

--- a/solvers/23-tox-ansible.yml
+++ b/solvers/23-tox-ansible.yml
@@ -5,10 +5,10 @@
 #
 # Solves:
 # - Task 1: Verify tox installation
-# - Task 2: Create a minimal tox configuration (tox.ini)
+# - Task 2: Configure tox-ansible (tox-ansible.ini)
 # - Task 3: Explore auto-generated environments
-# - Task 4: Run the tests (lint, unit, integration)
-# - Task 5: Run a group of tests
+# - Task 4: Run the tests (sanity, unit, integration)
+# - Task 5: Build and validate the collection (galaxy)
 #
 # =============================================================================
 
@@ -31,34 +31,34 @@
       changed_when: false
 
     # =========================================================================
-    # Task 2: Create a minimal tox configuration
+    # Task 2: Configure tox-ansible
     # =========================================================================
-    - name: "Task 2: Create tox.ini"
+    - name: "Task 2: Create tox-ansible.ini"
       ansible.builtin.copy:
-        dest: "{{ collection_dir }}/tox.ini"
+        dest: "{{ collection_dir }}/tox-ansible.ini"
         content: |
-          [tox]
-          # Global tox settings
-          envlist = lint, unit
-          skip_missing_interpreters = True
-          requires =
-              tox-ansible
-
-          [testenv]
-          # This section configures the default behavior for all environments
-          usedevelop = true
-          deps =
-              pytest
-              pytest-ansible
-              ansible-lint
-              molecule-plugins[podman]
-
           [ansible]
-          # Configuration specific to the tox-ansible plugin
-          # This limits the matrix to Ansible 2.15 and 2.16 to save time/resources
-          ansible_core_versions =
+          skip =
+              py3.7
+              py3.8
+              py3.9
+              py3.10
+              py3.11
+              py3.13
+              py3.14
+              2.9
+              2.10
+              2.11
+              2.12
+              2.13
+              2.14
               2.15
               2.16
+              2.17
+              2.18
+              2.19
+              devel
+              milestone
         mode: "0644"
         backup: true
 
@@ -67,42 +67,50 @@
     # =========================================================================
     - name: "Task 3: List all available tox environments"
       ansible.builtin.command:
-        cmd: "{{ collection_dir }}/.venv/bin/tox -l"
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/tox
+          --ansible -c tox-ansible.ini list
         chdir: "{{ collection_dir }}"
       changed_when: false
 
     # =========================================================================
     # Task 4: Run the tests
     # =========================================================================
-    - name: "Task 4: Run linting environment"
-      ansible.builtin.command:
-        cmd: "{{ collection_dir }}/.venv/bin/tox -e lint"
-        chdir: "{{ collection_dir }}"
-      changed_when: false
-      failed_when: false
-
-    - name: "Task 4: Run unit tests against Ansible 2.16"
-      ansible.builtin.command:
-        cmd: "{{ collection_dir }}/.venv/bin/tox -e py311-ansible2.16-unit"
-        chdir: "{{ collection_dir }}"
-      changed_when: false
-      failed_when: false
-
-    - name: "Task 4: Run integration tests (Molecule) against Ansible 2.16"
+    - name: "Task 4: Run sanity tests"
       ansible.builtin.command:
         cmd: >-
           {{ collection_dir }}/.venv/bin/tox
-          -e py311-ansible2.16-molecule-integration_hello_world
+          --ansible -c tox-ansible.ini -e sanity-py3.12-2.20
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      failed_when: false
+
+    - name: "Task 4: Run unit tests"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/tox
+          --ansible -c tox-ansible.ini -e unit-py3.12-2.20
+        chdir: "{{ collection_dir }}"
+      changed_when: false
+      failed_when: false
+
+    - name: "Task 4: Run integration tests (Molecule)"
+      ansible.builtin.command:
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/tox
+          --ansible -c tox-ansible.ini -e integration-py3.12-2.20
         chdir: "{{ collection_dir }}"
       changed_when: false
       failed_when: false
 
     # =========================================================================
-    # Task 5: Run a group of tests
+    # Task 5: Build and validate the collection
     # =========================================================================
-    - name: "Task 5: Run all tests for Ansible 2.16"
+    - name: "Task 5: Run galaxy environment"
       ansible.builtin.command:
-        cmd: "{{ collection_dir }}/.venv/bin/tox -f ansible2.16"
+        cmd: >-
+          {{ collection_dir }}/.venv/bin/tox
+          --ansible -c tox-ansible.ini -e galaxy
         chdir: "{{ collection_dir }}"
       changed_when: false
       failed_when: false

--- a/solvers/23-tox-ansible.yml
+++ b/solvers/23-tox-ansible.yml
@@ -19,7 +19,7 @@
 
   vars:
     collection_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 
   tasks:
     # =========================================================================

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -17,8 +17,8 @@
 
   vars:
     collection_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
-    project_dir: /home/rhel/myansibleproject
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+    project_dir: /projects/ansible-dev-tools-workspace
 
   tasks:
     # =========================================================================

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -19,41 +19,55 @@
     collection_dir: >-
       /projects/ansible-dev-tools-workspace/mynamespace.mycollection
     project_dir: /projects/ansible-dev-tools-workspace
+    ee_dir: /projects/ansible-dev-tools-workspace/mycollection-ee
 
   tasks:
+    # =========================================================================
+    # Task 0: Promote your playbook to the playbook project
+    # =========================================================================
+    - name: "Task 0: Copy mycowsay.yml to myplaybook project"
+      ansible.builtin.copy:
+        src: "{{ collection_dir }}/playbooks/mycowsay.yml"
+        dest: "{{ project_dir }}/myplaybook/mycowsay.yml"
+        remote_src: true
+        mode: "0644"
+
     # =========================================================================
     # Task 1: Define the Execution Environment definition file
     # The VS Code wizard creates an EE project. We create the files directly
     # and run the equivalent CLI commands.
     # =========================================================================
+    - name: "Task 1: Create EE project directory"
+      ansible.builtin.file:
+        path: "{{ ee_dir }}"
+        state: directory
+        mode: "0755"
 
     - name: "Task 1: Build collection tarball with ansible-galaxy"
       ansible.builtin.command:
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-galaxy collection build
-          --output-path {{ project_dir }}/
+          --output-path {{ ee_dir }}/
         chdir: "{{ collection_dir }}"
       changed_when: true
 
-    # Create the execution-environment.yml with local tarball reference
     - name: "Task 1: Create execution-environment.yml"
       ansible.builtin.copy:
-        dest: "{{ project_dir }}/execution-environment.yml"
+        dest: "{{ ee_dir }}/execution-environment.yml"
         content: |
           ---
           version: 3
           images:
             base_image:
-              name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:latest
+              name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
 
           dependencies:
-            ansible_core:
-              package_pip: ansible-core
-            ansible_runner:
-              package_pip: ansible-runner
+            python_interpreter:
+              python_path: /usr/bin/python3.12
+
             galaxy:
               collections:
-                # Tell Galaxy to look inside the local folder
+                # Tell Galaxy to look inside the local folder we created below
                 - name: collection_tarballs/mynamespace-mycollection-1.0.0.tar.gz
                   type: file
             python:
@@ -77,7 +91,7 @@
     - name: "Task 2: Run ansible-builder create to generate Containerfile"
       ansible.builtin.command:
         cmd: "{{ collection_dir }}/.venv/bin/ansible-builder create"
-        chdir: "{{ project_dir }}"
+        chdir: "{{ ee_dir }}"
       changed_when: true
 
     # =========================================================================
@@ -88,7 +102,7 @@
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-builder build
           -t mynamespace/mycollection-ee:latest -vvv
-        chdir: "{{ project_dir }}"
+        chdir: "{{ ee_dir }}"
       changed_when: true
       timeout: 600
 
@@ -113,7 +127,7 @@
           --execution-environment-image mycollection-ee
           --pull-policy never
           --mode stdout
-        chdir: "{{ project_dir }}"
+        chdir: "{{ ee_dir }}"
       changed_when: false
 
     - name: "Task 3: Test cowsay module documentation inside the EE"

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -27,26 +27,11 @@
     # and run the equivalent CLI commands.
     # =========================================================================
 
-    # First, disable editable mode before building the tarball
-    - name: "Task 1: Switch ade to standard mode for packaging"
-      ansible.builtin.command:
-        cmd: "{{ collection_dir }}/.venv/bin/ade install ."
-        chdir: "{{ collection_dir }}"
-      changed_when: true
-
-    # Build the collection tarball
     - name: "Task 1: Build collection tarball with ansible-galaxy"
       ansible.builtin.command:
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-galaxy collection build
           --output-path {{ project_dir }}/
-        chdir: "{{ collection_dir }}"
-      changed_when: true
-
-    # Re-enable editable mode
-    - name: "Task 1: Re-enable ade editable mode"
-      ansible.builtin.command:
-        cmd: "{{ collection_dir }}/.venv/bin/ade install -e ."
         chdir: "{{ collection_dir }}"
       changed_when: true
 

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -109,7 +109,7 @@
       ansible.builtin.command:
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-navigator run
-          {{ project_dir }}/mycowsay.yml
+          {{ collection_dir }}/playbooks/mycowsay.yml
           --execution-environment-image mycollection-ee
           --pull-policy never
           --mode stdout

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -17,7 +17,7 @@
 
   vars:
     collection_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection
     project_dir: /projects/ansible-dev-tools-workspace
 
   tasks:

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -109,7 +109,7 @@
       ansible.builtin.command:
         cmd: >-
           {{ collection_dir }}/.venv/bin/ansible-navigator run
-          {{ collection_dir }}/playbooks/mycowsay.yml
+          {{ project_dir }}/myplaybook/mycowsay.yml
           --execution-environment-image mycollection-ee
           --pull-policy never
           --mode stdout

--- a/solvers/32-ansible-sign.yml
+++ b/solvers/32-ansible-sign.yml
@@ -75,23 +75,25 @@
     # =========================================================================
     # Task 3: Create a MANIFEST.in file
     # =========================================================================
+    - name: "Task 2: Copy mycowsay.yml to playbook project"
+      ansible.builtin.copy:
+        src: "{{ collection_dir }}/playbooks/mycowsay.yml"
+        dest: "{{ project_dir }}/myplaybook/mycowsay.yml"
+        remote_src: true
+        mode: "0644"
+
     - name: "Task 3: Create MANIFEST.in file"
       ansible.builtin.copy:
-        dest: "{{ collection_dir }}/MANIFEST.in"
+        dest: "{{ project_dir }}/myplaybook/MANIFEST.in"
         content: |
-          # Exclude .venv FIRST before any includes
-          global-exclude .venv
-          global-exclude .venv/*
-          prune .venv
-
-          # Exclude .git
+          # Exclude development artifacts
           global-exclude .git
           global-exclude .git/*
           prune .git
 
-          # Now include what you want to sign
+          # Include files to sign
           include README.md
-          include playbooks/mycowsay.yml
+          include mycowsay.yml
         mode: "0644"
         backup: true
 
@@ -101,7 +103,7 @@
     - name: "Task 4: Sign the project files"
       ansible.builtin.command:
         cmd: "{{ collection_dir }}/.venv/bin/ansible-sign project gpg-sign ."
-        chdir: "{{ collection_dir }}"
+        chdir: "{{ project_dir }}/myplaybook"
       changed_when: true
 
     # =========================================================================
@@ -109,13 +111,13 @@
     # =========================================================================
     - name: "Task 5: Display checksum manifest"
       ansible.builtin.slurp:
-        src: "{{ collection_dir }}/.ansible-sign/sha256sum.txt"
+        src: "{{ project_dir }}/myplaybook/.ansible-sign/sha256sum.txt"
       register: r_checksum_manifest
 
     - name: "Task 5: Verify signed content"
       ansible.builtin.command:
         cmd: "{{ collection_dir }}/.venv/bin/ansible-sign project gpg-verify ."
-        chdir: "{{ collection_dir }}"
+        chdir: "{{ project_dir }}/myplaybook"
       changed_when: false
 
 

--- a/solvers/32-ansible-sign.yml
+++ b/solvers/32-ansible-sign.yml
@@ -77,7 +77,7 @@
     # =========================================================================
     - name: "Task 3: Create MANIFEST.in file"
       ansible.builtin.copy:
-        dest: "{{ project_dir }}/MANIFEST.in"
+        dest: "{{ collection_dir }}/MANIFEST.in"
         content: |
           # Exclude .venv FIRST before any includes
           global-exclude .venv
@@ -91,7 +91,7 @@
 
           # Now include what you want to sign
           include README.md
-          include mycowsay.yml
+          include playbooks/mycowsay.yml
         mode: "0644"
         backup: true
 
@@ -101,7 +101,7 @@
     - name: "Task 4: Sign the project files"
       ansible.builtin.command:
         cmd: "{{ collection_dir }}/.venv/bin/ansible-sign project gpg-sign ."
-        chdir: "{{ project_dir }}"
+        chdir: "{{ collection_dir }}"
       changed_when: true
 
     # =========================================================================
@@ -109,13 +109,13 @@
     # =========================================================================
     - name: "Task 5: Display checksum manifest"
       ansible.builtin.slurp:
-        src: "{{ project_dir }}/.ansible-sign/sha256sum.txt"
+        src: "{{ collection_dir }}/.ansible-sign/sha256sum.txt"
       register: r_checksum_manifest
 
     - name: "Task 5: Verify signed content"
       ansible.builtin.command:
         cmd: "{{ collection_dir }}/.venv/bin/ansible-sign project gpg-verify ."
-        chdir: "{{ project_dir }}"
+        chdir: "{{ collection_dir }}"
       changed_when: false
 
 

--- a/solvers/32-ansible-sign.yml
+++ b/solvers/32-ansible-sign.yml
@@ -20,7 +20,7 @@
 
   vars:
     collection_dir: >-
-      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+      /projects/ansible-dev-tools-workspace/mynamespace.mycollection
     project_dir: /projects/ansible-dev-tools-workspace
 
   tasks:

--- a/solvers/32-ansible-sign.yml
+++ b/solvers/32-ansible-sign.yml
@@ -20,8 +20,8 @@
 
   vars:
     collection_dir: >-
-      /home/rhel/myansibleproject/collections/ansible_collections/mynamespace/mycollection
-    project_dir: /home/rhel/myansibleproject
+      /projects/ansible-dev-tools-workspace/mynamespace/mycollection
+    project_dir: /projects/ansible-dev-tools-workspace
 
   tasks:
     # =========================================================================

--- a/solvers/32-ansible-sign.yml
+++ b/solvers/32-ansible-sign.yml
@@ -73,17 +73,6 @@
       changed_when: false
 
     # =========================================================================
-    # Task 2: Set up the environment
-    # =========================================================================
-    - name: "Task 2: Switch ade to standard mode (remove recursive symlinks)"
-      ansible.builtin.command:
-        cmd: >-
-          {{ collection_dir }}/.venv/bin/ade install
-          {{ collection_dir }}
-        chdir: "{{ project_dir }}"
-      changed_when: true
-
-    # =========================================================================
     # Task 3: Create a MANIFEST.in file
     # =========================================================================
     - name: "Task 3: Create MANIFEST.in file"
@@ -129,13 +118,6 @@
         chdir: "{{ project_dir }}"
       changed_when: false
 
-    - name: "Task 5: Switch ade back to editable mode"
-      ansible.builtin.command:
-        cmd: >-
-          {{ collection_dir }}/.venv/bin/ade install --editable
-          {{ collection_dir }}
-        chdir: "{{ project_dir }}"
-      changed_when: true
 
     # =========================================================================
     # Task 6: Enable verification in AAP executions


### PR DESCRIPTION
## Summary

- Rewrite all lab instructions from local workstation (`/home/rhel`) to DevSpaces browser-based environment (`/projects/ansible-dev-tools-workspace`)
- Update collection naming to dot-separated folder format (`mynamespace.mycollection`), playbook project at `myplaybook`
- Rewrite intro for DevSpaces split-view login flow, remove Lightspeed/extension reload references
- Update EE builder lab for AAP 26/RHEL 9 with tarball approach (`type: file` + `additional_build_files`)
- Rewrite tox-ansible lab to use `tox-ansible.ini` with `--ansible` flag and auto-discovered environments
- Add `build_ignore` workaround in `galaxy.yml` for ade editable mode bug (`.venv`, `collections`, `.tox`)
- Add cowsay pip dependency as a learning-from-failure step in module lab
- Move sign lab to work from `myplaybook/` directory instead of collection root
- Update all solvers to match rewritten instructions (paths, CLI syntax, env names, versions)
- Fix conftest.py collection path to use ade-managed `collections/` directory
- Update version references to match DevSpaces image (Python 3.12.12, ansible-core 2.20.5)
- Add `role=execute` to copy-pasteable code blocks missing the attribute

## Known remaining items

- Screenshot PLACEHOLDERs in intro (6 images pending)
- RHDP variable wiring (`{username}`, `{user_password}`) pending catalog item config
- Git clone URL for participants needs confirmation
- VS Code extension issues tracked in #17 and #18

## Test plan

- [ ] Validate each solver runs successfully in a DevSpaces workspace
- [ ] Walk through each lab module manually following the instructions
- [ ] Verify all code blocks with `role=execute` are copy-pasteable in Showroom
- [ ] Confirm `build_ignore` prevents bloated tarballs from `ansible-galaxy collection build`
- [ ] Test EE build with tarball approach end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)