### PR TITLE
Fix formatting and normalize structure across lab modules

### DIFF
--- a/content/modules/ROOT/pages/00-introduction.adoc
+++ b/content/modules/ROOT/pages/00-introduction.adoc
@@ -68,7 +68,9 @@ Before we begin, here are some tips to improve your lab experience:
 
 * The lab consists of several **Modules**. Each module contains one or more **Tasks**. When you finish a module, click the **Next** button at the bottom of the instructions sidebar to proceed.
 
-== Task 1: Launch the Dev Spaces workspace
+== Lab guide: Hands-on tasks
+
+=== Task 1: Launch the Dev Spaces workspace
 
 Red Hat OpenShift Dev Spaces gives you a full VS Code environment running in your browser, with all Ansible development tools pre-installed and configured. Instead of spending time installing tools locally, every participant gets an identical, ready-to-use workspace backed by an enterprise container platform.
 
@@ -113,7 +115,7 @@ TIP: Keep both tabs open throughout the lab — you will switch between the inst
 . Click the **Yes, I trust the Authors** button to trust the workspace authors.
 . Wait a few moments until the Ansible extension icon appears on the left sidebar.
 
-== Task 2: Explore the Ansible extension
+=== Task 2: Explore the Ansible extension
 
 . Click on the **Ansible** extension icon (the "A" logo) in the left activity bar to open the Ansible panel. You will see the **Ansible Development Tools** section with shortcuts and guided wizards to scaffold projects, manage execution environments, and perform other common Ansible development tasks. You will use several of these throughout the lab.
 
@@ -122,7 +124,7 @@ TIP: Keep both tabs open throughout the lab — you will switch between the inst
 // PLACEHOLDER: screenshot of the Ansible Development Tools welcome page
 image::00-introduction/ansible-getting-started.png[Ansible Development Tools welcome page showing available tools and walkthroughs,link=self,window=blank]
 
-== Task 3: Verify the development environment
+=== Task 3: Verify the development environment
 
 The majority of the exercises in this lab will be performed using the VS Code terminal.
 
@@ -151,7 +153,7 @@ adt --version
 +
 NOTE: The output will show the versions of all installed Ansible development tools. Versions may differ from the examples in the lab, this is expected.
 
-== Conclusion
+== Summary
 
 In this module, you have:
 
@@ -161,6 +163,6 @@ In this module, you have:
 
 This foundation prepares you for the remaining labs where you will create, test, and deploy Ansible automation content.
 
-== Contributing to this lab
+== Next steps
 
-If you see an error in this lab, fork and submit a pull request against link:https://github.com/rhpds/ansible-dev-tools-showroom[https://github.com/rhpds/ansible-dev-tools-showroom^]
+Please click the **Next** button below to proceed to xref:11-vscode-collection.adoc[Lab 1.1 - Creating a Collection with the VS Code Extension].

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -25,7 +25,7 @@ _A guide to using the Ansible extension for Visual Studio Code to scaffold a new
 
 `ansible-creator` is also integrated into the VS Code user interface through the Ansible extension for VS Code for even a smoother experience when developing content.
 
-In this exercise, you will create an Ansible collection and a playbook using the Ansible extension's wizard in VS Code.
+In this section, you will create an Ansible collection and a playbook using the Ansible extension's wizard in VS Code.
 
 == Learning objectives
 
@@ -41,7 +41,7 @@ image::11-vscode-editor-overview.png[VS Code editor inside the lab environment,l
 
 == Lab guide: Hands-on tasks
 
-In this exercise you will learn how to create, test, and deploy an Ansible collection using the `ansible-creator` tool through the Ansible extension for VS Code.
+In this section you will learn how to create, test, and deploy an Ansible collection using the `ansible-creator` tool through the Ansible extension for VS Code.
 
 For this lab, all necessary tools and dependencies are pre-installed and configured for you.
 
@@ -56,14 +56,14 @@ image::11-vscode-terminal.png[VS Code terminal,link=self,window=blank, opts="bor
 
 . **Scaffold a CLI collection with ansible-creator:** Using `ansible-creator` initialize a collection called `mynamespace.creatorcollection`:
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 ansible-creator init collection mynamespace.creatorcollection /projects/ansible-dev-tools-workspace/mynamespace.creatorcollection
 ----
 
 . **Inspect the generated collection structure and files:**
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 ls -lha /projects/ansible-dev-tools-workspace/mynamespace.creatorcollection
 ----
@@ -93,19 +93,19 @@ image::11-collection-create-dialog.png[Creating a Collection project,link=self,w
 .   **Fill out the collection details** in the new tab that opens. Use the following information:
 * **Namespace:** 
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 mynamespace
 ----
 * **Collection:**
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 mycollection
 ----
 * **Init path:**
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
@@ -144,19 +144,19 @@ image::11-playbook-create-dialog.png[Creating a Playbook project,link=self,windo
 .   **Fill out the playbook project details** in the new tab. Use the following information:
 * **Destination directory:**
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 /projects/ansible-dev-tools-workspace/myplaybook
 ----
 * **Namespace:**
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 mynamespace
 ----
 * **Collection:**
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 playbookcollection
 ----
@@ -181,7 +181,7 @@ image::11-explorer-icon.png[VS Code Explorer icon,link=self,window=blank, opts="
 
 .   **Open the collection folder** by clicking the **(1) Open Folder** button. In the path field, paste the following path **(2)** and click the blue **OK** button **(3)**.
 +
-[source,sh,role=execute]
+[source,bash,role=execute]
 ----
 /projects/ansible-dev-tools-workspace/mynamespace.mycollection/
 ----

--- a/content/modules/ROOT/pages/12-ade.adoc
+++ b/content/modules/ROOT/pages/12-ade.adoc
@@ -33,7 +33,7 @@ Ansible Dev Environment (`ade`) is a management tool for Ansible content develop
 - Providing configurable workspace isolation
 
 
-In this challenge, you will explore the content that was automatically generated for the collection you just created and learn how to customize your requirements using `ade`.
+In this section, you will explore the content that was automatically generated for the collection you just created and learn how to customize your requirements using `ade`.
 
 == Learning objectives
 
@@ -204,7 +204,7 @@ image::12-netcommon-system-packages-error.png[Command failure showing missing sy
 
 .   **Install the system dependencies** by running the following command in the VS Code terminal to install the missing OS packages:
 +
-[source,bash]
+[source,bash,role=execute]
 ----
 sudo dnf install -y python3-cffi python3-cryptography python3-lxml python3-pycparser
 ----

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -21,7 +21,7 @@ _A guide to adding a custom module to your Ansible collection and using it in a 
 
 == Lab briefing
 
-In this challenge, you will be adding content in the form of a Ansible **module plugin** to the collection you created, and then using the module for a new playbook, which you will fix with `ansible-lint` before running it with `ansible-navigator`.
+In this section, you will be adding content in the form of an Ansible **module plugin** to the collection you created, and then using the module for a new playbook, which you will fix with `ansible-lint` before running it with `ansible-navigator`.
 
 == Learning objectives
 
@@ -36,7 +36,7 @@ After completing this module, you will be able to:
 
 == Lab guide: Hands-on tasks
 
-In this exercise, you will copy an existing Python module into your collection's `plugins/modules` directory. While you can develop your own modules from scratch, we will use a pre-written one for simplicity.
+In this section, you will copy an existing Python module into your collection's `plugins/modules` directory. While you can develop your own modules from scratch, we will use a pre-written one for simplicity.
 
 === Task 1: Add a custom module to the collection
 

--- a/content/modules/ROOT/pages/index.adoc
+++ b/content/modules/ROOT/pages/index.adoc
@@ -46,7 +46,7 @@ The following modules are included in this lab:
 By the end of this workshop, you will be able to:
 
 * Use the **Ansible extension for VS Code** features for a rich editing experience.
-* Learn all the creation tools, including `ansible-creator` to scaffold new collections and content, `adt` (Ansible development tools) for a unified command-line tools management, `ade` (Ansible development environment) for managing collection dependencies and virtual environments and `ansible-navigator` for a feature-rich terminal-based user interface to run and test your execution environments..
+* Learn all the creation tools, including `ansible-creator` to scaffold new collections and content, `adt` (Ansible development tools) for a unified command-line tools management, `ade` (Ansible development environment) for managing collection dependencies and virtual environments and `ansible-navigator` for a feature-rich terminal-based user interface to run and test your execution environments.
 * Test your content with `ansible-lint` for checking playbooks against recommended practices, `molecule` for testing your collections in isolated, reproducible environments, `pytest-ansible` for functional testing of your modules, and `tox-ansible` for bringing it all together in multiple combinations.
 * Deploy to production by packaging your Collection content with `ansible-galaxy` and `ansible-builder`, and applying secure supply chain practices with `ansible-sign`.
 


### PR DESCRIPTION
## Summary

- Standardize all code blocks to `[source,bash]` (was `source,sh` in 11-vscode-collection)
- Add missing `role=execute` to `sudo dnf install` block in 12-ade
- Fix double period typo in index.adoc
- Normalize task heading levels in 00-introduction (`===` under `== Lab guide`)
- Rename `Conclusion` to `Summary`, `Contributing` to `Next steps` in 00-introduction
- Standardize terminology to "section" (was mixed challenge/exercise)

Supersedes #13 and #14 (closed due to conflicts after the devspaces-instructions rewrite).

## Test plan

- [ ] Verify Antora build completes without errors
- [ ] Check copy-to-clipboard buttons appear on fixed blocks in Showroom UI
- [ ] Visual review of rendered pages for consistent structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)