### PR TITLE
Fix lab instructions from testing walkthrough

### DIFF
--- a/content/modules/ROOT/pages/00-introduction.adoc
+++ b/content/modules/ROOT/pages/00-introduction.adoc
@@ -43,9 +43,9 @@ In this workshop, you will use these tools through a consistent development work
 
 == Lab environment
 
-For this workshop, your development environment runs in link:https://access.redhat.com/products/red-hat-openshift-dev-spaces/[Red Hat OpenShift Dev Spaces^], which provides consistent, reproducible development environments based on the open-source project link:https://eclipse.dev/che/[Eclipse Che^].
+For this workshop, your development environment runs in Red Hat OpenShift Dev Spaces, which provides consistent, reproducible development environments based on the open-source project Eclipse Che.
 
-Dev Spaces provides a VS Code environment configured by a link:https://devfile.io[devfile^], a YAML file that defines the entire workspace as code, including all necessary tools, runtimes, and project source. This ensures every participant has an identical setup.
+Dev Spaces provides a VS Code environment configured by a devfile, a YAML file that defines the entire workspace as code, including all necessary tools, runtimes, and project source. This ensures every participant has an identical setup.
 
 The lab environment includes:
 
@@ -152,6 +152,8 @@ adt --version
 ----
 +
 NOTE: The output will show the versions of all installed Ansible development tools. Versions may differ from the examples in the lab, this is expected.
+
+. Close the terminal by clicking the trash can icon on the terminal panel or by typing `exit` in the terminal.
 
 == Summary
 

--- a/content/modules/ROOT/pages/11-vscode-collection.adoc
+++ b/content/modules/ROOT/pages/11-vscode-collection.adoc
@@ -72,6 +72,8 @@ NOTE: You should see the scaffolded collection directory structure including fil
 
 . **Congrats:** You created a default collection. This collection was created for demonstration purposes only — in the following tasks you will create the collection used throughout the rest of the lab.
 
+. Close the terminal by clicking the trash can icon on the terminal panel or by typing `exit` in the terminal.
+
 === Task 1: Explore the Ansible extension
 
 First, let's explore the Ansible extension for VS Code.
@@ -171,34 +173,19 @@ image::11-playbook-create-form.png[Creating a Playbook project,link=self,window=
 Note: playbook project created at /projects/ansible-dev-tools-workspace/myplaybook
 ----
 
-=== Task 4: Open the collection folder and configure the Python environment
+=== Task 4: Open the collection folder
 
-Now you will open the collection folder in VS Code and configure the Python interpreter to use the virtual environment that was created with the collection.
+Now you will explore the collection files that were generated for you.
 
 .   **Open the file Explorer** by clicking the Explorer icon (the icon with two files) in the VS Code left sidebar.
 +
 image::11-explorer-icon.png[VS Code Explorer icon,link=self,window=blank, opts="border"]
 
-.   **Open the collection folder** by clicking the **(1) Open Folder** button. In the path field, paste the following path **(2)** and click the blue **OK** button **(3)**.
-+
-[source,bash,role=execute]
-----
-/projects/ansible-dev-tools-workspace/mynamespace.mycollection/
-----
-+
-image::11-open-folder-dialog.png[Opening a folder in VS Code,link=self,window=blank, opts="border"]
-
-.   **View the scaffolded files** once the VS Code screen reloads. You will see the complete directory structure and all the files created by the Ansible extension for your new collection in the left sidebar.
+.   **View the scaffolded files.** In the file explorer sidebar, expand the `mynamespace.mycollection` folder. You will see the complete directory structure and all the files created by the Ansible extension for your new collection.
 +
 image::11-collection-explorer-view.png[Scaffolded collection files in the Explorer view,link=self,window=blank, opts="border"]
 
 .   **Activate the Ansible extension** by clicking on the `galaxy.yml` file in the file explorer. This ensures VS Code recognizes the project as an Ansible collection and activates the Ansible language features.
-
-.   **Copy the virtual environment path.** In the file explorer sidebar, locate the `.venv` folder, **right-click** on it, and select **Copy Path**.
-
-.   **Open the Python interpreter selector** by clicking the Python version indicator in the bottom-right corner of the VS Code status bar.
-
-.   In the dropdown that appears at the top of the screen, select **Enter interpreter path...** and paste the `.venv` path you copied. This configures VS Code to use the collection's virtual environment, which includes all the Ansible development tools and dependencies.
 
 === Task 5: Compare the CLI-generated with the VS Code-generated collections
 

--- a/content/modules/ROOT/pages/12-ade.adoc
+++ b/content/modules/ROOT/pages/12-ade.adoc
@@ -59,7 +59,12 @@ First, you will activate the Python virtual environment (`.venv`) that `ansible-
 
 .   **Open the `galaxy.yml` file** by clicking on it in the left sidebar.
 
-.   **Activate the Python virtual environment** by clicking the banner that reads `Python: Select Interpreter` in the bottom status bar of VS Code. From the dropdown menu that appears at the top, select the recommended option: **Python 3.12.12 ('.venv': venv)**.
+.   **Activate the Python virtual environment.** The `.venv` created by `ansible-creator` needs to be set as the active Python interpreter for VS Code:
++
+.. In the VS Code file explorer sidebar, **right-click** on the `.venv` folder and select **Copy Path**.
+.. Click the **Python version** shown in the bottom status bar of VS Code (it may say `Python: Select Interpreter` or show a system Python version). A dropdown will appear at the top of the editor.
+.. Select **Enter interpreter path...** from the dropdown.
+.. **Paste** the path you copied and press **Enter**.
 +
 image::12-python-env-selector.png[Selecting the Python virtual environment in VS Code,link=self,window=blank, opts="border"]
 
@@ -182,6 +187,20 @@ The output should look like this:
     Note: All required system packages are installed.
 ----
 
+.   **Update `build_ignore` in `galaxy.yml`.** When `ade` manages your collection, it creates directories like `.venv` and `collections` inside the collection root. These are development artifacts that should not be included when building the collection tarball. The `build_ignore` field in `galaxy.yml` tells `ansible-galaxy collection build` to exclude them. Open `galaxy.yml` and update the `build_ignore` section to:
++
+[source,yaml]
+----
+build_ignore:
+  - .gitignore
+  - changelogs/.plugin-cache.yaml
+  - .venv
+  - collections
+  - .tox
+----
++
+This ensures that development tooling directories are excluded from the packaged collection artifact. The `.venv` and `collections` entries prevent `ade`-managed content from bloating the tarball, and `.tox` excludes test runner artifacts from `tox-ansible`. We are adding these entries manually due to a known bug — in a future version, `ade` is expected to handle this automatically.
+
 .   **Check the dependency tree** by running `ade tree -v` to see the installed dependencies.
 
 .   **Add another collection dependency** by going back to the `galaxy.yml` file and adding `"ansible.netcommon": "*"` to the `dependencies:` list. Save the file. The result should look like this:
@@ -212,20 +231,6 @@ sudo dnf install -y python3-cffi python3-cryptography python3-lxml python3-pycpa
 .   **Re-run the `ade` installation.** Now, run `ade install -e .` one more time in the terminal. It should succeed.
 
 .   **Check the new dependency tree.** Finally, run `ade tree -v` again. The output will now show that `ade` has successfully added the `ansible.netcommon` collection to your environment, along with its Python requirements.
-
-.   **Update `build_ignore` in `galaxy.yml`.** When `ade` manages your collection, it creates directories like `.venv` and `collections` inside the collection root. These are development artifacts that should not be included when building the collection tarball. The `build_ignore` field in `galaxy.yml` tells `ansible-galaxy collection build` to exclude them. Open `galaxy.yml` and update the `build_ignore` section to:
-+
-[source,yaml]
-----
-build_ignore:
-  - .gitignore
-  - changelogs/.plugin-cache.yaml
-  - .venv
-  - collections
-  - .tox
-----
-+
-This ensures that development tooling directories are excluded from the packaged collection artifact. The `.venv` and `collections` entries prevent `ade`-managed content from bloating the tarball, and `.tox` excludes test runner artifacts from `tox-ansible`. We are adding these entries manually due to a known bug — in a future version, `ade` is expected to handle this automatically.
 
 NOTE: Remember the "Install collection from source code (editable mode)" option you selected during the Collection creation wizard? That option used `ade install -e` to automatically create the virtual environment (`.venv`) that you are using now.
 

--- a/content/modules/ROOT/pages/13-module.adoc
+++ b/content/modules/ROOT/pages/13-module.adoc
@@ -141,7 +141,7 @@ image::13-lint-settings-fix.png[Ansible Lint settings,link=self,window=blank, op
 
 Now that your playbook is lint-free, let's run it. Go back to the **VS Code file Explorer** view.
 
-.   **Run with `ansible-playbook`.** In the VS Code file explorer, **right-click** your `mycowsay.yml` playbook. From the context menu, select **Run Ansible Playbook**.
+.   **Run with `ansible-playbook`.** In the VS Code file explorer, **click** on `mycowsay.yml` to open it in the editor, then **right-click** the file in the explorer. From the context menu, select **Run Ansible Playbook**.
 +
 The playbook will **fail** with an error similar to:
 +
@@ -172,11 +172,11 @@ ade install -e .
 +
 You should see `cowsay` included in the installed packages.
 
-.   **Run the playbook again.** **Right-click** your `mycowsay.yml` playbook and select **Run Ansible Playbook**. This time it should succeed and display a friendly cow saying "Hello, Ansible!".
+.   **Run the playbook again.** Make sure `mycowsay.yml` is open in the editor, then **right-click** it in the file explorer and select **Run Ansible Playbook**. This time it should succeed and display a friendly cow saying "Hello, Ansible!".
 +
 image::13-cowsay-playbook-output.png[Playbook output with cowsay message,link=self,window=blank, opts="border"]
 
-.   **Run with `ansible-navigator`.** **Right-click** the playbook again, but this time select **Run with Ansible Navigator**. This will launch the Terminal User Interface (TUI).
+.   **Run with `ansible-navigator`.** With `mycowsay.yml` still open in the editor, **right-click** the file in the explorer again, but this time select **Run with Ansible Navigator**. This will launch the Terminal User Interface (TUI).
 +
 image::13-cowsay-navigator-tui.png[Ansible Navigator TUI,link=self,window=blank, opts="border"]
 

--- a/content/modules/ROOT/pages/21-molecule.adoc
+++ b/content/modules/ROOT/pages/21-molecule.adoc
@@ -188,7 +188,25 @@ Finally, you will use the command line to run the Molecule test scenario and obs
 cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection/extensions/
 ----
 
-.   **Run a bare Molecule test.** First, run `molecule test` without specifying a scenario. 
+.   **Create a default Molecule configuration.** In the VS Code Explorer sidebar, **right-click** on the `molecule/` folder inside `extensions/` and select **New File**. Name it:
++
+[source]
+----
+default/molecule.yml
+----
++
+VS Code will create the `default/` directory automatically. **Paste** the following content into the new file and **save** it:
++
+[source,yaml]
+----
+---
+scenario:
+  name: default
+----
++
+This empty default scenario prevents Molecule from showing a warning when no default configuration is found.
+
+.   **Run a bare Molecule test.** First, run `molecule test` without specifying a scenario.
 +
 [source,bash,role=execute]
 ----

--- a/content/modules/ROOT/pages/22-pytest-ansible.adoc
+++ b/content/modules/ROOT/pages/22-pytest-ansible.adoc
@@ -69,7 +69,7 @@ In this task, we will test the custom `cowsay` module developed earlier in the c
 
 === Task 1: Create the test inventory
 
-. *Create the `inventory` file inside the `mycollection/tests` directory:*
+. *Create the `inventory` file inside the `mynamespace.mycollection/tests` directory:*
 +
 [source,ini,role=execute]
 ----
@@ -81,7 +81,7 @@ localhost ansible_connection=local ansible_python_interpreter=python3
 
 === Task 2: Create the test configuration
 
-. *Inside the `mycollection/tests/` directory*, create a `conftest.py` file with the following content:
+. *Inside the `mynamespace.mycollection/tests/` directory*, create a `conftest.py` file with the following content:
 +
 [source,python,role=execute]
 ----
@@ -125,7 +125,7 @@ The `conftest.py` file is a special pytest configuration file that runs before a
 
 === Task 3: Create the test file
 
-. *Inside the `mycollection/tests/` directory*, create a `test_cowsay.py` file and add the following content:
+. *Inside the `mynamespace.mycollection/tests/` directory*, create a `test_cowsay.py` file and add the following content:
 +
 [source,python,role=execute]
 ----
@@ -193,6 +193,23 @@ This test validates both the module's execution (no failures, correct change sta
 cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
 ----
 
+. *Suppress upstream warnings.* Open the `pyproject.toml` file in the collection root and update the `filterwarnings` list in the `[tool.pytest.ini_options]` section to include the additional filters. The result should look like this:
++
+[source,toml,role=execute]
+----
+[tool.pytest.ini_options]
+addopts = ["-vvv", "-n", "2", "--log-level", "WARNING", "--color", "yes"]
+filterwarnings = [
+    "ignore:AnsibleCollectionFinder has already been configured",
+    "ignore::DeprecationWarning:pytest_ansible",
+    "ignore::UserWarning:pytest_ansible",
+    "ignore::DeprecationWarning:multiprocessing",
+]
+testpaths = ["tests"]
+----
++
+This filters out known deprecation and host management warnings from `pytest-ansible` that are not relevant to your tests. Save the file.
+
 . *Run the tests:*
 +
 [source,bash,role=execute]
@@ -204,20 +221,17 @@ pytest
 +
 [source,text]
 ----
- tests/integration/test_integration.py::test_integration[NOTSET] s                                                   33% ███▍      
-[gw0] SKIPPED tests/integration/test_integration.py 
- tests/unit/test_basic.py::test_basic ✓                                                                              67% ██████▋   
-[gw0] PASSED tests/unit/test_basic.py 
+ tests/integration/test_integration.py::test_integration[NOTSET] s                                                   33% ███▍
+[gw0] SKIPPED tests/integration/test_integration.py
+ tests/unit/test_basic.py::test_basic ✓                                                                              67% ██████▋
+[gw0] PASSED tests/unit/test_basic.py
  tests/test_cowsay.py::test_cowsay_module ✓                                                                         100% ██████████
-[gw1] PASSED tests/test_cowsay.py 
-
-[... warnings here ...]
+[gw1] PASSED tests/test_cowsay.py
 
 Results (1.15s):
        2 passed
        1 skipped
 ----
-NOTE: You might see warnings between the Results and PASSED tests/test_cowsay.py. That's ok. 
 
 
 ---

--- a/content/modules/ROOT/pages/23-tox-ansible.adoc
+++ b/content/modules/ROOT/pages/23-tox-ansible.adoc
@@ -50,6 +50,13 @@ Before we configure anything, let's verify that `tox` and the plugin are install
 
 .   **Open the VS Code Terminal.**
 
+.   **Navigate to your collection root:**
++
+[source,bash,role=execute]
+----
+cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection/
+----
+
 .   **Check the tox version and plugins:**
 +
 [source,bash,role=execute]
@@ -59,16 +66,17 @@ tox --version
 +
 **Output analysis:**
 You should see output similar to:
-`tox 4.x.x from ... with tox-ansible-2.x.x`
 +
-Crucially, look for **`with tox-ansible`**. This confirms the plugin is active.
-
-.   **Navigate to your collection root:**
+[source,text]
+----
+$ tox --version
+ROOT: No loadable tox.ini or setup.cfg or pyproject.toml or tox.toml found, assuming empty tox.ini at /projects/ansible-dev-tools-workspace/mynamespace.mycollection
+4.53.0 from /projects/ansible-dev-tools-workspace/mynamespace.mycollection/.venv/lib64/python3.12/site-packages/tox/__init__.py
+registered plugins:
+    tox-ansible-26.3.0 at /projects/ansible-dev-tools-workspace/mynamespace.mycollection/.venv/lib64/python3.12/site-packages/tox_ansible/plugin.py
+----
 +
-[source,bash,role=execute]
-----
-cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection/
-----
+The `ROOT: No loadable tox.ini` message is expected — tox-ansible uses its own `tox-ansible.ini` file instead of `tox.ini`. Look for **`tox-ansible`** in the registered plugins list. This confirms the plugin is active.
 
 === Task 2: Configure tox-ansible
 
@@ -142,13 +150,31 @@ Now we let tox orchestrate the execution. Remember to always pass `--ansible -c 
 tox --ansible -c tox-ansible.ini -e sanity-py3.12-2.20
 ----
 +
-Tox creates a virtual environment, installs the required dependencies, and runs `ansible-test sanity` against your collection.
+Tox creates a virtual environment, installs the required dependencies, and runs `ansible-test sanity` against your collection. When it finishes, you should see:
++
+[source,text]
+----
+  sanity-py3.12-2.20: OK (38.48=setup[4.34]+cmd[28.34,0.02,5.78] seconds)
+  congratulations :) (38.58 seconds)
+----
 
 .   **Run Unit Tests:**
 +
 [source,bash,role=execute]
 ----
 tox --ansible -c tox-ansible.ini -e unit-py3.12-2.20
+----
++
+Expected output:
++
+[source,text]
+----
+tests/unit/test_basic.py::test_basic
+[gw0] [100%] PASSED tests/unit/test_basic.py::test_basic
+
+============================================================== 1 passed in 0.74s ==============================================================
+  unit-py3.12-2.20: OK (32.74=setup[9.41]+cmd[22.03,1.30] seconds)
+  congratulations :) (32.84 seconds)
 ----
 
 .   **Run Integration Tests (Molecule):**
@@ -158,6 +184,17 @@ tox --ansible -c tox-ansible.ini -e unit-py3.12-2.20
 ----
 tox --ansible -c tox-ansible.ini -e integration-py3.12-2.20
 ----
++
+Expected output:
++
+[source,text]
+----
+============================================================= 1 skipped in 0.69s ==============================================================
+  integration-py3.12-2.20: OK (32.88=setup[9.27]+cmd[22.34,1.28] seconds)
+  congratulations :) (32.98 seconds)
+----
++
+NOTE: The `1 skipped` result is expected — the scaffolded `test_integration.py` is a placeholder. The actual integration tests run through Molecule scenarios.
 +
 This automatically:
     1.  Creates a fresh virtual environment.
@@ -174,6 +211,16 @@ The `galaxy` environment builds your collection tarball and runs `galaxy-importe
 [source,bash,role=execute]
 ----
 tox --ansible -c tox-ansible.ini -e galaxy
+----
++
+Expected output:
++
+[source,text]
+----
+...ansible-lint run complete
+Collection loading complete
+  galaxy: OK (22.00=setup[8.21]+cmd[13.79] seconds)
+  congratulations :) (22.10 seconds)
 ----
 
 

--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -66,6 +66,8 @@ cp /projects/ansible-dev-tools-workspace/mynamespace.mycollection/playbooks/myco
 
 The EE configuration is defined in `execution-environment.yml`. To access the features of modern Ansible tooling, we must explicitly declare `version: 3` in the definition file.
 
+. *Create the destination directory.* The VS Code wizard requires the destination directory to exist before creating the project. In the VS Code file explorer sidebar, **right-click** on the workspace root (`ansible-dev-tools-workspace`) and select **New Folder**. Name it `mycollection-ee`.
+
 . *Create the Execution environment project in VS Code:*
 +
 Open the **Ansible extension** in the VS Code sidebar and click the **Execution environment project** option under the "INITIALIZE" menu.
@@ -80,9 +82,14 @@ image::31-ee-wizard-sidebar.png[EE wizard creator in VS Code,link=self,window=bl
 /projects/ansible-dev-tools-workspace/mycollection-ee
 ----
 +
-* **Base image:** Select the `registry.redhat.io` option from the dropdown to use the Red Hat supported image.
+* **Base image:** In the dropdown, select **Other** and enter the following community base image:
 +
-NOTE: This will require to be logged in to the registry before building the image. For the lab this is not required.
+[source,bash,role=execute]
+----
+ghcr.io/ansible-community/community-ee-base:2.20.5-1
+----
++
+NOTE: For this lab we use the community EE base image to avoid registry authentication and to show the different alternatives available. In production, you would typically use the Red Hat supported base image (`registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest`), which is the same image you will find in AAP when deploying to production and requires authentication to the Red Hat registry.
 * **Additional collections:**
 +
 [source,bash,role=execute]
@@ -109,7 +116,7 @@ mycollection-ee
 +
 image::31-ee-create-project.png[Creating an EE project,link=self,window=blank, opts="border"]
 +
-TIP: The CLI equivalent of this wizard is: `ansible-creator init execution_env --ee-base-image registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest --ee-collections mynamespace.mycollection --ee-python-deps cowsay --ee-name mycollection-ee /projects/ansible-dev-tools-workspace/mycollection-ee`
+TIP: The CLI equivalent of this wizard is: `ansible-creator init execution_env --ee-base-image ghcr.io/ansible-community/community-ee-base:2.20.5-1 --ee-collections mynamespace.mycollection --ee-python-deps cowsay --ee-name mycollection-ee /projects/ansible-dev-tools-workspace/mycollection-ee`
 
 . *Open the `execution-environment.yml` file:*
 +
@@ -125,11 +132,11 @@ This configuration defines the base image, includes the collection dependencies,
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
+    name: ghcr.io/ansible-community/community-ee-base:2.20.5-1
 
 dependencies:
   python_interpreter:
-    python_path: /usr/bin/python3.12
+    python_path: /usr/bin/python3
 
   python:
     - cowsay
@@ -139,7 +146,6 @@ dependencies:
       - name: mynamespace.mycollection
 
 options:
-  package_manager_path: /usr/bin/microdnf
   tags:
     - mycollection-ee
 ----
@@ -158,11 +164,11 @@ Replace the contents of `execution-environment.yml` with:
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
+    name: ghcr.io/ansible-community/community-ee-base:2.20.5-1
 
 dependencies:
   python_interpreter:
-    python_path: /usr/bin/python3.12
+    python_path: /usr/bin/python3
 
   galaxy:
     collections:
@@ -180,15 +186,13 @@ additional_build_files:
 options:
   tags:
     - mycollection-ee
-  package_manager_path: /usr/bin/microdnf
 ----
 +
 **Understanding the customizations:**
 +
-* `python_interpreter.python_path`: The AAP 26 base image ships with Python 3.12 — this tells `ansible-builder` to use it instead of the default Python 3.9.
+* `python_interpreter.python_path`: Uses `/usr/bin/python3` to match whatever Python version the base image ships.
 * `additional_build_files`: Copies the collection tarball into the build context under `collection_tarballs/`.
 * `type: file` in the `galaxy` section: Tells `ansible-galaxy` to install the collection from the local tarball instead of downloading it from Galaxy.
-* `package_manager_path`: The base image uses `microdnf` as the package manager.
 
 . *Save the file.*
 
@@ -199,6 +203,10 @@ Before building the EE, we need to package the collection. The `build_ignore` en
 [source,bash,role=execute]
 ----
 cd /projects/ansible-dev-tools-workspace/mynamespace.mycollection
+----
++
+[source,bash,role=execute]
+----
 ansible-galaxy collection build --output-path /projects/ansible-dev-tools-workspace/mycollection-ee/
 ----
 

--- a/content/modules/ROOT/pages/32-ansible-sign.adoc
+++ b/content/modules/ROOT/pages/32-ansible-sign.adoc
@@ -47,7 +47,7 @@ Using ansible-sign together with the Automation Hub collection signing feature a
 
 NOTE: In this lab we will only cover the workstation side of the content signing. You can apply what you learned here to verify content on your own AAP instance later.
 
-=== Task 1: Create a GPG key 
+=== Task 1: Create a GPG key
 
 To use `ansible-sign` your workstation needs to have a GNU Privacy Guard (GPG) key available to cryptographically sign the content. Although it exceeds the scope of this workshop, we will create one quickly to show the end to end steps.
 
@@ -55,14 +55,20 @@ To use `ansible-sign` your workstation needs to have a GNU Privacy Guard (GPG) k
 +
 [source,bash,role=execute]
 ----
- sudo dnf install pinentry-curses -y
+sudo dnf install pinentry-curses -y
 ----
 
-. *Create a gpg.txt file with the following content:*
+. *Create a GPG batch file in VS Code:* In the VS Code file explorer sidebar, **right-click** on the workspace root (`ansible-dev-tools-workspace`) and select **New File**. Name it:
 +
 [source,bash,role=execute]
 ----
-cat >~/gpg.txt <<EOF
+gpg.txt
+----
++
+Paste the following content:
++
+[source,text,role=execute]
+----
 %echo Generating a basic OpenPGP key
 Key-Type: default
 Key-Length: 4096
@@ -74,18 +80,17 @@ Name-Email: student@localhost
 Expire-Date: 0
 %no-ask-passphrase
 %no-protection
-# Do a commit here, so that we can later print "done" :-)
 %commit
 %echo done
-EOF
 ----
-
++
+Save the file.
 
 .  *Generate the gpg key:*
 +
 [source,bash,role=execute]
 ----
-gpg --batch --gen-key ~/gpg.txt
+gpg --batch --gen-key /projects/ansible-dev-tools-workspace/gpg.txt
 ----
 
 . *Verify the key is created:*
@@ -95,20 +100,40 @@ gpg --batch --gen-key ~/gpg.txt
 gpg --list-secret-keys
 ----
 
-=== Task 2: Set up the environment
+=== Task 2: Prepare the project for signing
 
-This task demonstrates how to cryptographically sign an Ansible Project using `ansible-sign`. We will be using the `myplaybook` project directory — the playbook project you created earlier and where you copied your `mycowsay.yml` playbook in the previous module.
+`ansible-sign` checksums every file in the project directory and compares them against the `MANIFEST.in`. To keep the signing clean and avoid checksum mismatches from development artifacts, we will create a dedicated directory with only the files we want to sign.
 
-. *Make sure you are in the playbook project directory:*
+. *Create the signed playbook directory.* In the VS Code file explorer sidebar, **right-click** on the workspace root (`ansible-dev-tools-workspace`) and select **New Folder**. Name it:
 +
 [source,bash,role=execute]
 ----
-cd /projects/ansible-dev-tools-workspace/myplaybook
+mysignedplaybook
+----
+
+. *Copy the playbook file.* In the VS Code file explorer, expand `mynamespace.mycollection` > `playbooks`, **right-click** on `mycowsay.yml` and select **Copy**. Then **right-click** on the `mysignedplaybook` folder and select **Paste**.
+
+. *Create a README.md file.* **Right-click** on the `mysignedplaybook` folder and select **New File**. Name it `README.md` and add a short description:
++
+[source,text,role=execute]
+----
+# My Signed Playbook
+
+This project contains the signed mycowsay playbook.
+----
++
+Save the file.
+
+. *Navigate to the signed playbook directory:*
++
+[source,bash,role=execute]
+----
+cd /projects/ansible-dev-tools-workspace/mysignedplaybook
 ----
 
 === Task 3: Create a MANIFEST.in file
 
-. *In VS Code, create a new file called `MANIFEST.in`* in the `myplaybook` directory. This file controls which files are included in the checksum manifest that `ansible-sign` creates and verifies.
+. *In VS Code, create a new file called `MANIFEST.in`* in the `mysignedplaybook` directory by **right-clicking** on the folder and selecting **New File**. This file controls which files are included in the checksum manifest that `ansible-sign` creates and verifies.
 +
 For this lab, we will sign just two files to keep the output simple. In a production environment, you would include all project files to ensure full supply chain integrity.
 +


### PR DESCRIPTION
## Summary

Fixes and improvements found during end-to-end testing of all lab modules:

- **Lab 1.1**: Remove Open Folder dialog step (unnecessary in Dev Spaces), remove venv setup (moved to 1.2)
- **Lab 1.2**: Fix Python interpreter selection to use "Enter interpreter path" instead of dropdown (no longer listed by default), move `build_ignore` step earlier in Task 4
- **Lab 1.3**: Add instruction to open `mycowsay.yml` in editor before right-click actions (required for context menu)
- **Lab 2.1**: Add default molecule scenario stub to prevent `CRITICAL 'molecule/default/molecule.yml' glob failed` warning
- **Lab 2.2**: Fix `mycollection/tests` → `mynamespace.mycollection/tests` paths, add `filterwarnings` to `pyproject.toml` to suppress upstream pytest-ansible deprecation warnings
- **Lab 2.3**: Reorder `cd` before `tox --version`, add expected output for all tox environments (sanity, unit, integration, galaxy)
- **Lab 3.1**: Add `mkdir` step for `mycollection-ee` directory (wizard bug), switch from `registry.redhat.io` to `ghcr.io/ansible-community/community-ee-base:2.20.5-1` to avoid registry auth, update `python_path` to `/usr/bin/python3`, remove `microdnf` reference, split collection build commands

## Test plan

- [ ] Walk through all labs end-to-end in a fresh Dev Spaces workspace
- [ ] Verify Python interpreter selection works with the new "Enter interpreter path" flow
- [ ] Verify molecule default scenario prevents the CRITICAL warning
- [ ] Verify pytest runs clean without warnings after filterwarnings update
- [ ] Verify EE build succeeds with community-ee-base image

🤖 Generated with [Claude Code](https://claude.com/claude-code)