### PR TITLE
Fix Lab 3.1 EE blueprint and base image instructions

### DIFF
--- a/content/modules/ROOT/pages/31-ansible-builder.adoc
+++ b/content/modules/ROOT/pages/31-ansible-builder.adoc
@@ -82,7 +82,8 @@ image::31-ee-wizard-sidebar.png[EE wizard creator in VS Code,link=self,window=bl
 /projects/ansible-dev-tools-workspace/mycollection-ee
 ----
 +
-* **Base image:** In the dropdown, select **Other** and enter the following base image:
+* **Base image:** Leave the dropdown as **-- Select Base Image --**.
+* **Custom base image:** Enter the following base image:
 +
 [source,bash,role=execute]
 ----
@@ -135,15 +136,15 @@ images:
     name: image-registry.openshift-image-registry.svc:5000/openshift/ee-minimal-rhel9:latest
 
 dependencies:
-  python_interpreter:
-    python_path: /usr/bin/python3
-
-  python:
-    - cowsay
-
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
   galaxy:
     collections:
       - name: mynamespace.mycollection
+  python:
+    - cowsay
 
 options:
   tags:

--- a/solvers/31-ansible-builder.yml
+++ b/solvers/31-ansible-builder.yml
@@ -63,7 +63,7 @@
 
           dependencies:
             python_interpreter:
-              python_path: /usr/bin/python3.12
+              python_path: /usr/bin/python3
 
             galaxy:
               collections:


### PR DESCRIPTION
## Summary
- Update initial EE blueprint to match actual wizard output (`ansible_core`/`ansible_runner` pip deps)
- Update final customized EE to use `python3` instead of `python3.12`
- Fix base image instructions: use **Custom base image** field, leave dropdown as **-- Select Base Image --**
- Update solver to match lab guide

## Test plan
- [ ] Verify EE blueprint YAML blocks render correctly in Antora preview
- [ ] Confirm solver stays consistent with lab instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)